### PR TITLE
Remove period

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -578,7 +578,7 @@ const Page = () => (
         <Feature
           icon="welcome"
           color="rgb(255,88,88)"
-          name="Existing clubs welcome."
+          name="Existing clubs welcome"
           desc={
             <>
               When established CS clubs join, they get all the Hack&nbsp;Club


### PR DESCRIPTION
"Existing clubs welcome." is the only heading with a period. This PR removes the period so it's consistent with the other headings.

s/o to @Ninja9000 for pointing this out!