### PR TITLE
Pitch bank better

### DIFF
--- a/components/bank/Landing.js
+++ b/components/bank/Landing.js
@@ -58,7 +58,7 @@ export default function Landing() {
                     }
                   }}
                 >
-                  The bank for hackers to <Underline>make ideas real</Underline>
+                  The bank for you to <Underline>make your ideas real</Underline>
                   .
                 </Heading>
                 <Container variant="copy">


### PR DESCRIPTION
Pitch Bank better by relating it to the viewer and removing “for hackers”, reducing an awkward interruption, which the rest of the page makes clear anyways.