### PR TITLE
Add og image for /bank

### DIFF
--- a/pages/bank.js
+++ b/pages/bank.js
@@ -28,7 +28,8 @@ export default function Bank() {
         <Meta
           as={Head}
           title="Bank"
-          description="Hack Club Bank provides a 501(c)(3) status-backed organization fund optimized for high school hackathons including invoicing, debit cards, check sending, pre-written legal forms, automated tax filing, and transparent finances. Get fiscal sponsorship designed to help you run great events."
+          description="Hack Club Bank provides a 501(c)(3) status-backed fund optimized for high school hackathons including invoicing, debit cards, check sending, pre-written legal forms, automated tax filing, and transparent finances. Get fiscal sponsorship designed to help you run a great organization."
+          image="https://cloud-7xnjpfu14-hack-club-bot.vercel.app/0og_image.png"
         />
         <style children={styles} />
         <Box>

--- a/pages/bank.js
+++ b/pages/bank.js
@@ -29,7 +29,7 @@ export default function Bank() {
           as={Head}
           title="Bank"
           description="Hack Club Bank provides a 501(c)(3) status-backed fund optimized for high school hackathons including invoicing, debit cards, check sending, pre-written legal forms, automated tax filing, and transparent finances. Get fiscal sponsorship designed to help you run a great organization."
-          image="https://cloud-7xnjpfu14-hack-club-bot.vercel.app/0og_image.png"
+          image="https://cloud-og86rfngo-hack-club-bot.vercel.app/0og_image-2.png"
         />
         <style children={styles} />
         <Box>


### PR DESCRIPTION
This PR adds an og image for the hackclub.com/bank page:

![og_image-2](https://user-images.githubusercontent.com/72365100/132184550-a0b4f2f8-ffd8-483c-b231-054dd7983819.png)


