### PR TITLE
Fix chrome autofill text color

### DIFF
--- a/components/bank/Signup.js
+++ b/components/bank/Signup.js
@@ -26,7 +26,9 @@ function Field({ placeholder, label, name, type, value, onChange }) {
         placeholder={placeholder}
         name={name}
         type={type}
-        sx={{ bg: 'dark' }}
+        sx={{
+          bg: 'dark'
+        }}
         onChange={onChange}
         value={value}
         required

--- a/pages/bank.js
+++ b/pages/bank.js
@@ -17,6 +17,10 @@ const styles = `
     color: #ffffff;
     text-shadow: none;
   }
+input:-webkit-autofill {
+  -webkit-text-fill-color: white;
+}
+
 `
 
 export default function Bank() {


### PR DESCRIPTION
This PR fixes the text color on chrome autofill to make it white instead of the default (black). fixes #198 

