### PR TITLE
Fix button on Elon page

### DIFF
--- a/components/bank/Testimonials.js
+++ b/components/bank/Testimonials.js
@@ -215,6 +215,7 @@ function Event({
                     ml={[0, 'auto']}
                     sx={{ textTransform: 'none' }}
                     variant="primary"
+                    title="🎶 take a look, it's in our books 🎵"
                   >
                     See Finances
                   </Button>

--- a/pages/elon.js
+++ b/pages/elon.js
@@ -133,7 +133,7 @@ export default () => (
             Hack Club is a global community of high school makers & student-led
             coding clubs. We’ve got a 24/7 Slack chatroom of 10k+ teenagers
             learning to code & building amazing projects, & you’ll fit right in.
-          </Text><br />
+          </Text><br /><br />
           <NextLink href="/" passHref>
             <Button bg="cyan" as="a">
               Learn more

--- a/pages/elon.js
+++ b/pages/elon.js
@@ -133,7 +133,7 @@ export default () => (
             Hack Club is a global community of high school makers & student-led
             coding clubs. We’ve got a 24/7 Slack chatroom of 10k+ teenagers
             learning to code & building amazing projects, & you’ll fit right in.
-          </Text>
+          </Text><br />
           <NextLink href="/" passHref>
             <Button bg="cyan" as="a">
               Learn more


### PR DESCRIPTION
<img width="661" alt="Screen Shot 2021-09-15 at 9 56 34 PM" src="https://user-images.githubusercontent.com/72365100/133552011-f876ed12-60ef-42aa-bc7e-1a0ed1916194.png">
This PR adds a break so the button is on a new line