### PR TITLE
Add hiring header to events designer page

### DIFF
--- a/pages/jobs/events-designer.js
+++ b/pages/jobs/events-designer.js
@@ -41,6 +41,10 @@ export default () => (
         fontSize: [2, 3]
       }}
     >
+      <Heading variant="headline" sx={{ fontWeight: 700, fontSize: [4, 5], mb: 4 }}>
+        Hack Club is hiring an Events Designer!
+      </Heading>
+
       <Text as="p" sx={{ fontWeight: 700 }}>We do crazy things...</Text>
 
       <Grid


### PR DESCRIPTION
@zachlatta suggested a bit more clarity on the Events Designer job page, I just added a header to the top of the body copy:

> **Hack Club is hiring an Events Designer!**

Open to feedback on tweaks but I see this as just a simple incremental improvement.