### PR TITLE
Add bank tech lead job description

### DIFF
--- a/components/jobs/bank-tech-lead/jd.mdx
+++ b/components/jobs/bank-tech-lead/jd.mdx
@@ -8,26 +8,26 @@ In this role, you will work in an environment where we value teamwork, communica
 
 **Roles and responsibilities:**
 
-* Work with Executive Director to define product roadmap and business strategy
-* Build and lead team of Hack Clubbers to execute on engineering roadmap and create a strong shipping culture around Bank
-* Lead and manage relationships with technical partners that integrate Bank into their products
-* Every day think about how Hack Club Bank can be better for Hack Clubbers, and work with Executive Director to design the product roadmap around that
-* Manage operations lead, who will report to you and is responsible for onboarding calls, day-to-day financial management tasks, and customer success
+- Work with Executive Director to define product roadmap and business strategy
+- Build and lead team of Hack Clubbers to execute on engineering roadmap and create a strong shipping culture around Bank
+- Lead and manage relationships with technical partners that integrate Bank into their products
+- Every day think about how Hack Club Bank can be better for Hack Clubbers, and work with Executive Director to design the product roadmap around that
+- Manage operations lead, who will report to you and is responsible for onboarding calls, day-to-day financial management tasks, and customer success
 
 **Required skills:**
 
-* Senior-level expertise in Ruby on Rails
-* Prior experience managing small teams of engineers
-* Strong familiarity with open source
-* Product-oriented mindset
-* Excellent project planning and written communication skills
-* You love working with teenagers
+- Senior-level expertise in Ruby on Rails
+- Prior experience managing small teams of engineers
+- Strong familiarity with open source
+- Product-oriented mindset
+- Excellent project planning and written communication skills
+- You love working with teenagers
 
 **Nice to have:**
 
-* You have either built popular open source projects, or held leadership-level roles in major open source projects
-* Experience writing financial software, building resilient systems, and implementing security best practices
-* Good eye for design / frontend design skills
+- You have either built popular open source projects, or held leadership-level roles in major open source projects
+- Experience writing financial software, building resilient systems, and implementing security best practices
+- Good eye for design / frontend design skills
 
 **Title:** Tech Lead, Hack Club Bank
 

--- a/components/jobs/bank-tech-lead/jd.mdx
+++ b/components/jobs/bank-tech-lead/jd.mdx
@@ -1,0 +1,38 @@
+[Hack Club](https://hackclub.com) is on a mission to create a new generation of technical leaders by building the most inclusive, technical, and shipping-oriented community of teenage programmers in the world.
+
+We are building 4 key programs - [clubs](https://hackclub.com), [Slack](https://hackclub.com/slack/), [hackathons](https://hackathons.hackclub.com), and [Bank](https://hackclub.com/bank/) - and are working toward transforming Hack Club into a modern equivalent of the Girl and Boy Scouts from the 20th century.
+
+Hack Club is hiring an Engineering Lead for [Hack Club Bank](https://hackclub.com/bank/), our in-house financial software used by 1,500 Hack Clubbers to financially power their Hack Clubs, hackathons, and student-organized nonprofits. When teenagers use Hack Club Bank, we act as their backing financial and legal entity, allowing them to leverage our 501(c)(3) nonprofit status to receive donations and use our beautiful in-house software to manage and spend their funds.
+
+In this role, you will work in an environment where we value teamwork, communication, and creativity. You love coding, are passionate about growing people, have deep empathy for users and team members, and love shipping work publicly.
+
+**Roles and responsibilities:**
+
+* Work with Executive Director to define product roadmap and business strategy
+* Build and lead team of Hack Clubbers to execute on engineering roadmap and create a strong shipping culture around Bank
+* Lead and manage relationships with technical partners that integrate Bank into their products
+* Every day think about how Hack Club Bank can be better for Hack Clubbers, and work with Executive Director to design the product roadmap around that
+* Manage operations lead, who will report to you and is responsible for onboarding calls, day-to-day financial management tasks, and customer success
+
+**Required skills:**
+
+* Senior-level expertise in Ruby on Rails
+* Prior experience managing small teams of engineers
+* Strong familiarity with open source
+* Product-oriented mindset
+* Excellent project planning and written communication skills
+* You love working with teenagers
+
+**Nice to have:**
+
+* You have either built popular open source projects, or held leadership-level roles in major open source projects
+* Experience writing financial software, building resilient systems, and implementing security best practices
+* Good eye for design / frontend design skills
+
+**Title:** Tech Lead, Hack Club Bank
+
+**Location:** We have an in-person office in Burlington, Vermont where our 8 person team works collaboratively. While we have a strong preference for in-person and can assist with relocation, we're flexible and eager to accommodate for the right candidate. 
+
+**Compensation:** Competitive salary, commensurate with experience. We offer healthcare and 4 weeks paid vacation.
+
+**How to apply:** Email <jobs@hackclub.com> with "the spice must flow'' in the subject line, 3 bullet points demonstrating why you would be exceptional for the role, and your resume / GitHub / GitLab / sourcehut.

--- a/pages/jobs/bank-ops-associate.js
+++ b/pages/jobs/bank-ops-associate.js
@@ -24,10 +24,10 @@ export default () => (
       }}
     >
       <Container sx={{ textAlign: 'center', color: 'white' }}>
-        <Heading as="h1" variant="title">
+        <Heading as="h1" variant="title" mb={30}>
           Bank Operations Associate
         </Heading>
-        <Text variant="headline">
+        <Text variant="headline" sx={{ fontWeight: 400 }}>
           New job open as of May 21st, 2021.
         </Text>
       </Container>

--- a/pages/jobs/bank-ops-lead.js
+++ b/pages/jobs/bank-ops-lead.js
@@ -24,10 +24,10 @@ export default () => (
       }}
     >
       <Container sx={{ textAlign: 'center', color: 'white' }}>
-        <Heading as="h1" variant="title">
+        <Heading as="h1" variant="title" mb={30}>
           Bank Operations Lead
         </Heading>
-        <Text variant="headline">
+        <Text variant="headline" sx={{ fontWeight: 400 }}>
           Closed as of March 5th, 2021.
         </Text>
       </Container>

--- a/pages/jobs/bank-tech-lead.js
+++ b/pages/jobs/bank-tech-lead.js
@@ -1,0 +1,47 @@
+import { BaseStyles, Box, Container, Heading, Text } from 'theme-ui'
+import Head from 'next/head'
+import Nav from '../../components/nav'
+import Meta from '@hackclub/meta'
+import JobDescription from '../../components/jobs/bank-tech-lead/jd.mdx'
+import ForceTheme from '../../components/force-theme'
+
+export default () => (
+  <>
+    <Meta
+      as={Head}
+      title="Bank Operations Lead"
+      description="Hack Club is a hiring a Bank Operations Lead as the 7th full-time member of our team in Burlington, Vermont."
+      image="https://workshop-cards.hackclub.com/Bank Ops Lead @ Hack Club.png?fontSize=175px&brand=HQ"
+    />
+    <ForceTheme theme="light" />
+    <Nav />
+    <Box
+      as="section"
+      sx={{
+        pt: [5, 6],
+        pb: [4, 5],
+        backgroundImage: theme => theme.util.gx('purple', 'red')
+      }}
+    >
+      <Container sx={{ textAlign: 'center', color: 'white' }}>
+        <Heading as="h1" variant="title" mb={30}>
+          Bank Tech Lead
+        </Heading>
+        <Text variant="headline" sx={{ fontWeight: 400 }}>
+          New job open as of December 11th, 2021.
+        </Text>
+      </Container>
+    </Box>
+    <Container
+      as={BaseStyles}
+      variant="copy"
+      sx={{
+        pt: [3, 4],
+        pb: [4, 5],
+        fontSize: [2, 3]
+      }}
+    >
+      <JobDescription />
+    </Container>
+  </>
+)

--- a/pages/jobs/brand-director.js
+++ b/pages/jobs/brand-director.js
@@ -24,10 +24,10 @@ export default () => (
       }}
     >
       <Container sx={{ textAlign: 'center', color: 'white' }}>
-        <Heading as="h1" variant="title">
+        <Heading as="h1" variant="title" mb={30}>
           Hack Club Brand Director
         </Heading>
-        <Text variant="headline">
+        <Text variant="headline" sx={{ fontWeight: 400 }}>
           Tell the story of Hack Club. New job open as of February 8th, 2021.
         </Text>
       </Container>

--- a/pages/jobs/clubs-lead.js
+++ b/pages/jobs/clubs-lead.js
@@ -24,10 +24,10 @@ export default () => (
       }}
     >
       <Container sx={{ textAlign: 'center', color: 'white' }}>
-        <Heading as="h1" variant="title">
+        <Heading as="h1" variant="title" mb={30}>
           Clubs Lead @ Hack Club
         </Heading>
-        <Text variant="headline">
+        <Text variant="headline" sx={{ fontWeight: 400 }}>
           New job open as of May 18th, 2021.
         </Text>
       </Container>

--- a/pages/jobs/executive-assistant.js
+++ b/pages/jobs/executive-assistant.js
@@ -24,10 +24,10 @@ export default () => (
       }}
     >
       <Container sx={{ textAlign: 'center', color: 'white' }}>
-        <Heading as="h1" variant="title">
+        <Heading as="h1" variant="title" mb={30}>
           Executive Assistant @&nbsp;Hack&nbsp;Club
         </Heading>
-        <Text variant="headline">
+        <Text variant="headline" sx={{ fontWeight: 400 }}>
           New job open as of October 18th, 2021.
         </Text>
       </Container>

--- a/pages/jobs/journalist.js
+++ b/pages/jobs/journalist.js
@@ -24,10 +24,10 @@ export default () => (
       }}
     >
       <Container sx={{ textAlign: 'center', color: 'white' }}>
-        <Heading as="h1" variant="title">
+        <Heading as="h1" variant="title" mb={30}>
           Hack Club Journalist
         </Heading>
-        <Text variant="headline">
+        <Text variant="headline" sx={{ fontWeight: 400 }}>
           Tell the story of Hack Club. New job open as of March 9, 2021.
         </Text>
       </Container>

--- a/pages/jobs/philanthropy-position.js
+++ b/pages/jobs/philanthropy-position.js
@@ -24,10 +24,10 @@ export default () => (
       }}
     >
       <Container sx={{ textAlign: 'center', color: 'white' }}>
-        <Heading as="h1" variant="title">
-        Philanthropy Position @&nbsp;Hack&nbsp;Club
+        <Heading as="h1" variant="title" mb={30}>
+          Philanthropy Position @&nbsp;Hack&nbsp;Club
         </Heading>
-        <Text variant="headline">
+        <Text variant="headline" sx={{ fontWeight: 400 }}>
           New job open as of October 20th, 2021.
         </Text>
       </Container>


### PR DESCRIPTION
This adds the job description for the new Bank Tech Lead role.

Right now it's primarily just the job description pasted in with a bit of formatting. If a richer style is desired I'm happy to make something custom, similar to the events designer page!

I also made very minor updates to the styles of other job pages for consistency. At some point, we'll need a better way of doing this (maybe something with `getStaticPaths`) but it's fine for the time being.

cc/ @zachlatta 