### PR TITLE
Add redirect for /jobs

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -96,6 +96,11 @@ const nextConfig = {
         permanent: true
       },
       {
+        source: '/jobs/',
+        destination: 'https://jobs.hackclub.com',
+        permanent: false
+      },
+      {
         source: '/jobs/creative-director/',
         destination: '/jobs/brand-director/',
         permanent: false


### PR DESCRIPTION
This PR sets a redirect from <https://hackclub.com/jobs> to <https://jobs.hackclub.com>. Currently `/jobs` is a 404, but I think it would be intuitive to visit hackclub.com/jobs if someone is curious about job openings at Hack Club and because the job description paths are `/jobs/position`