### PR TITLE
Default link style begone

### DIFF
--- a/pages/philosophy.js
+++ b/pages/philosophy.js
@@ -1,10 +1,9 @@
 import Meta from '@hackclub/meta'
 import Head from 'next/head'
-import { Box, Heading, Container, Text, Button } from 'theme-ui'
+import { Box, Heading, Container, Text, Button, Link } from 'theme-ui'
 import Nav from '../components/nav'
 import styled from '@emotion/styled'
 import Footer from '../components/footer'
-import t from '@hackclub/theme'
 
 const Header = styled(Box)`
   color: white;
@@ -218,7 +217,7 @@ export default function Philosophy() {
           <Box sx={{ fontSize: [3, 3] }}>
             Just as the best carpenters didn’t learn in the classroom, neither
             did the best programmers. Through our{' '}
-            <a href="/workshops">workshops</a>, you’ll be walked through
+            <Link href="/workshops">workshops</Link>, you’ll be walked through
             building projects. Starting out, you won’t understand how the code
             works, but you’ll build understanding as you go. You’ll get stuck
             along the way, but we’re here to help.
@@ -269,7 +268,13 @@ export default function Philosophy() {
           >
             Start a club
           </Button>
-          <Button sx={{ bg: 'white', color: 'red' }} as="a" href="https://hackclub.com/slack">Join our Slack</Button>
+          <Button
+            sx={{ bg: 'white', color: 'red' }}
+            as="a"
+            href="https://hackclub.com/slack"
+          >
+            Join our Slack
+          </Button>
         </Box>
       </Box>
       <Footer light />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,9 +1131,9 @@ camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001202, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001228:
-  version "1.0.30001230"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz"
-  integrity sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==
+  version "1.0.30001285"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001285.tgz"
+  integrity sha512-KAOkuUtcQ901MtmvxfKD+ODHH9YVDYnBt+TGYSz2KIfnq22CiArbUxXPN9067gNbgMlnNYRSwho8OPXZPALB9Q==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
I noticed that one of the links on the Philosophy page doesn't have the Hack Club theme style. This PR fixes it by making it use the `Link` component. Also some lockfile changes from `caniuse-lite`.
<img width="175" alt="Screen Shot 2021-12-08 at 10 23 15 PM" src="https://user-images.githubusercontent.com/72365100/145344892-a44da4cb-b180-4cb3-81de-31ec1181e852.png">
<img width="336" alt="Screen Shot 2021-12-08 at 10 23 04 PM" src="https://user-images.githubusercontent.com/72365100/145344895-2ea052a4-b20d-4da5-a5f3-dffdc7aa7e92.png">

