### PR TITLE
Open Secret Santa Airtable form in current tab

### DIFF
--- a/pages/santa.js
+++ b/pages/santa.js
@@ -186,7 +186,7 @@ function Field({ placeholder, label, name, type, value, onChange }) {
 function Signup() {
   const [values, setValues] = useState({})
   return (
-    <Base method="get" target="_blank" action="https://hack.af/santa-signup">
+    <Base method="get" action="https://hack.af/santa-signup">
       <Heading sx={{ color: 'black', textAlign: 'left', mb: 2 }}>
         Register!
       </Heading>


### PR DESCRIPTION
At the moment the Airtable form opens in a new tab, leaving the existing tab with the partially filled out form

![image](https://user-images.githubusercontent.com/20099646/146177404-db2aa8e6-7ba8-45df-92fb-e71128be2e56.png)

This PR opens the Airtable form URL in the current tab, rather than in a new tab.