### PR TITLE
Fix zrl's signature on /elon page

### DIFF
--- a/components/elon/copy.mdx
+++ b/components/elon/copy.mdx
@@ -19,6 +19,6 @@ Hack&nbsp;Club’s mission is to build a new generation of hackers. This starts 
 
 To every Hack Clubber: Elon is now supporting you and your work, so go forth and do amazing things. We can’t wait to show Elon what you make.
 
-<Signature />
+<Signature fname="Zach" lname="Latta" />
 
 Zach Latta, Founder


### PR DESCRIPTION
Previously:
<img width="1104" alt="Screen Shot 2022-01-13 at 1 19 54 PM" src="https://user-images.githubusercontent.com/72365100/149411623-6072f7ef-3068-4413-b105-7e190dce8c56.png">


This PR fixes:
<img width="1104" alt="Screen Shot 2022-01-13 at 1 25 53 PM" src="https://user-images.githubusercontent.com/72365100/149411637-bffba92f-5103-4726-9d03-6273db691130.png">

