### PR TITLE
Opensource page fixes

### DIFF
--- a/pages/opensource.js
+++ b/pages/opensource.js
@@ -60,7 +60,7 @@ const Page = ({ repos }) => (
       description="Explore our finances, code, planning documents and more."
       image="https://workshop-cards.hackclub.com/Open%20Source.png?theme=dark&fontSize=350px&brand=HQ"
     />
-    <Nav />
+    <Nav color="text" />
     <Box
       as="header"
       sx={{
@@ -154,15 +154,15 @@ const Page = ({ repos }) => (
         Content
       </Heading>
       <Grid columns={2} gap={3} mt={2} mb={[4]}>
-        <BankProject name="Workshops" url={`https://github.com/hackclub/hackclub/tree/main/workshops`} />
+        <BankProject
+          name="Workshops"
+          url={`https://github.com/hackclub/hackclub/tree/main/workshops`}
+        />
         <BankProject
           name="VIP Newsletters"
           url={`https://github.com/hackclub/vip-newsletters`}
         />
-        <BankProject
-          name="Meetings"
-          url={`https://meetings.hackclub.com`}
-        />
+        <BankProject name="Meetings" url={`https://meetings.hackclub.com`} />
       </Grid>
       <Heading
         variant="headline"

--- a/pages/opensource.js
+++ b/pages/opensource.js
@@ -1,17 +1,4 @@
-import {
-  Box,
-  Button,
-  Card,
-  Container,
-  Flex,
-  Grid,
-  Heading,
-  Image,
-  Input,
-  Link as A,
-  Text
-} from 'theme-ui'
-import theme from '@hackclub/theme'
+import { Box, Card, Container, Flex, Grid, Heading, Text } from 'theme-ui'
 import Meta from '@hackclub/meta'
 import Icon from '@hackclub/icons'
 import Head from 'next/head'


### PR DESCRIPTION
Previously, the text in the navbar was white, so the text was not visible because it blends in with the background. This PR makes the text black.

I also removed unused imports from the opensource page and formatted according to [Prettier](https://github.com/hackclub/v3/blob/c0110c05a40cad24e20e4ac21172cad8a56f44d7/prettier.config.js).

Prev:
<img width="926" alt="Screen Shot 2022-01-13 at 1 29 59 PM" src="https://user-images.githubusercontent.com/72365100/149412369-628aa261-2fe9-4b02-a936-a4853a159334.png">
This PR:
<img width="1187" alt="Screen Shot 2022-01-13 at 1 29 46 PM" src="https://user-images.githubusercontent.com/72365100/149412429-5f43aeac-73b6-48fb-906e-baba197d25bd.png">

