### PR TITLE
Use `<Link>` for header flag

### DIFF
--- a/components/flag.js
+++ b/components/flag.js
@@ -58,9 +58,9 @@ const Base = styled('a')`
 `
 
 const Flag = props => (
-  // <Link href="/" passHref>
-  <Base href="https://hackclub.com/" title="Homepage" {...props} />
-  // </Link>
+  <Link href="/" passHref>
+    <Base href="https://hackclub.com/" title="Homepage" {...props} />
+  </Link>
 )
 
 export default Flag


### PR DESCRIPTION
This PR re-enables the use of `<Link>` for the header flag - now clicks are done on the client-side for extra speed
