### PR TITLE
Remove Build from GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,15 +4,6 @@ on:
   - pull_request
 
 jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-      - run: yarn install
-      - run: yarn build
-
   lint:
     name: Lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
This feel redundant given we have Vercel checking it for us, thoughts?