### PR TITLE
Force theme on opensource page

### DIFF
--- a/pages/opensource.js
+++ b/pages/opensource.js
@@ -5,6 +5,7 @@ import Head from 'next/head'
 import Nav from '../components/nav'
 import Footer from '../components/footer'
 import { Octokit } from '@octokit/rest'
+import ForceTheme from '../components/force-theme'
 
 export const BankProject = ({ name, url }) => (
   <Card
@@ -47,6 +48,7 @@ const Page = ({ repos }) => (
       description="Explore our finances, code, planning documents and more."
       image="https://workshop-cards.hackclub.com/Open%20Source.png?theme=dark&fontSize=350px&brand=HQ"
     />
+    <ForceTheme theme="light" />
     <Nav color="text" />
     <Box
       as="header"


### PR DESCRIPTION
If you go from a dark themed page such as https://hackclub.com/bank to https://hackclub.com/opensource, the page is dark. This PR adds the ForceTheme component so that the page is always light.

<img width="1369" alt="Screen Shot 2022-01-30 at 9 08 31 PM" src="https://user-images.githubusercontent.com/72365100/151742101-359b2af5-ecb2-438f-a8e0-5f1796d662eb.png">
