### PR TITLE
Add redirect countdown to `/bank/success`

### DIFF
--- a/pages/bank/success.js
+++ b/pages/bank/success.js
@@ -1,13 +1,41 @@
 import Head from 'next/head'
+import { useRouter } from 'next/router'
+import { useEffect, useRef, useState } from 'react'
 import { Container, Text, Flex, Link, Image } from 'theme-ui'
 import ForceTheme from '../../components/force-theme'
 
 export default function ApplicationSuccess() {
+  const router = useRouter()
+
+  const [counter, setCounter] = useState(15)
+
+  const interval = useRef()
+
+  useEffect(() => {
+    interval.current = setInterval(() => {
+      setCounter(c => {
+        if (c <= 1) {
+          clearInterval(interval.current)
+          router.push('/bank')
+          return 0
+        } else {
+          return c - 1
+        }
+      })
+    }, 1000)
+
+    return () => {
+      clearInterval(interval.current)
+    }
+  }, [router])
+
+  const cancelRedirect = () => {
+    clearInterval(interval.current)
+    setCounter(null)
+  }
+
   return (
     <Container variant="copy">
-      <Head>
-        <meta httpEquiv="refresh" content="15;url=https://hackclub.com/bank" />
-      </Head>
       <ForceTheme theme="dark" />
       <Flex
         sx={{
@@ -35,6 +63,14 @@ export default function ApplicationSuccess() {
           or on the <Link href="/slack">Hack Club Slack</Link> in the{' '}
           <strong>#bank</strong> channel.
         </Text>
+        {counter !== null && (
+          <Flex sx={{ justifyContent: 'center' }}>
+            <Text sx={{ mr: 3 }}>Redirecting in {counter} seconds.</Text>
+            <Link sx={{ cursor: 'pointer' }} onClick={() => cancelRedirect()}>
+              Cancel
+            </Link>
+          </Flex>
+        )}
       </Flex>
     </Container>
   )


### PR DESCRIPTION
The automatic 15-second redirect is a bit jarring, what if there was a countdown?

<img width="952" alt="Screen Shot 2022-02-02 at 3 19 57 PM" src="https://user-images.githubusercontent.com/34525547/152230880-1ac3886a-6b8d-4442-a417-8358bedc04f0.png">
