### PR TITLE
Formatting fixes on Donor Engagement job posting

### DIFF
--- a/components/jobs/vp-DonorEngagement/jd.mdx
+++ b/components/jobs/vp-DonorEngagement/jd.mdx
@@ -1,117 +1,118 @@
 Interested in a dynamic, quickly-growing entrepreneurial nonprofit with teens and technology at its core? Hack Club supports high school coders in 36 states and 22 countries in starting coding clubs, hackathons, and building awesome projects.
 
-As **VP, Donor Engagement** (a new position), you'll shape and advance our philanthropy strategy, and lead on executing it alongside Hack Club's COO, its board, and a team of designers, video, and social media contractors. You'll be working closely with an incredibly talented and unusual creative team of engineers, international journalists, billionaire coders, and teen hackers!
+As **VP of Donor Engagement** (a new position), you'll shape and advance our philanthropy strategy, and lead on executing it alongside Hack Club's COO, its board, and a team of designers, video, and social media contractors. You'll be working closely with an incredibly talented and unusual creative team of engineers, international journalists, billionaire coders, and teen hackers!
 
 To date, we've raised $6 million from a dozen committed donors---including Elon Musk---and the right candidate can leverage our highly-connected network to build a sustainable $5 to $7 million per year donor network with relationship building, storytelling, and collaboration.
 
 We're seeking a deeply experienced senior executive with proven success in increasing the gift size of existing donors and leverage networks to attract new donors. The work has begun: you will be able to rely on our board and circle of supporters to open some doors.
 
 **WHAT WE OFFER**
--   An opportunity to build a new, truly equitable educational system that gives every teenager a chance, regardless of background, race or gender. ** Hack Club's mission is to build a cultural youth institution for the 21st century, with 21st century skills, built by and for teenagers. ** This starts in high school, where Hack Club students learn to be technically proficient, build their friend network, learn to raise and spend money, and develop into kind, curious, thoughtful, optimistic, and honest leaders
 
--   The thrill of a start-up and a greenfield to build things from scratch
+- An opportunity to build a new, truly equitable educational system that gives every teenager a chance, regardless of background, race or gender. ** Hack Club's mission is to build a cultural youth institution for the 21st century, with 21st century skills, built by and for teenagers. ** This starts in high school, where Hack Club students learn to be technically proficient, build their friend network, learn to raise and spend money, and develop into kind, curious, thoughtful, optimistic, and honest leaders
 
--   The support of an Executive Assistant, and a budget to contract for needed skills such as design, grant-writing and prospecting. Our expectation is you'll grow your team as our fundraising increases. Hack Club has a staff of eight and an operating budget of $1.5 million per year... growing exponentially.
+- The thrill of a start-up and a greenfield to build things from scratch
+
+- The support of an Executive Assistant, and a budget to contract for needed skills such as design, grant-writing and prospecting. Our expectation is you'll grow your team as our fundraising increases. Hack Club has a staff of eight and an operating budget of $1.5 million per year... growing exponentially.
 
 **PAY:** Starts at $140,000 (commensurate with experience)
 
 ** BENEFITS **
+
 - 4 weeks paid time off (PTO)
 
--   11 paid holidays
+- 11 paid holidays
 
--   $1000 per month toward the cost of health insurance
+- $1000 per month toward the cost of health insurance
 
--   Flexible schedule
+- Flexible schedule
 
--   Full-time remote (occasional visits to the Vermont office)
+- Full-time remote (occasional visits to the Vermont office)
 
--   Hardware stipend of $2000 (e.g., MacBook Air, big monitor, external keyboard and mouse)
+- Hardware stipend of $2000 (e.g., MacBook Air, big monitor, external keyboard and mouse)
 
 **WHAT YOU BRING**
 
--   A demonstrated track record of progressively responsible experience in identifying, cultivating, and soliciting major gifts
+- A demonstrated track record of progressively responsible experience in identifying, cultivating, and soliciting major gifts
 
--   You have closed on at least one $1 million gift
+- You have closed on at least one $1 million gift
 
--   You have closed gifts from Silicon Valley and the tech industry
+- You have closed gifts from Silicon Valley and the tech industry
 
--   You're energized by an entrepreneurial setting; you thrive in new and ambiguous situations that require figuring out new solutions, rather than taking predetermined paths to success
+- You're energized by an entrepreneurial setting; you thrive in new and ambiguous situations that require figuring out new solutions, rather than taking predetermined paths to success
 
--   You are known for your clear and compelling written and verbal presentations
+- You are known for your clear and compelling written and verbal presentations
 
--   You are a consummate professional and your work ethic is an example to others
+- You are a consummate professional and your work ethic is an example to others
 
--   You have an ability to lead effectively through relationships, persuasion and influence, and you navigate difficult conversations with grace and empathy
+- You have an ability to lead effectively through relationships, persuasion and influence, and you navigate difficult conversations with grace and empathy
 
--   You are a both a doer and a thinker ...you readily roll up your sleeves to get into the data while also driving towards the bigger picture
+- You are a both a doer and a thinker ...you readily roll up your sleeves to get into the data while also driving towards the bigger picture
 
--   You have developed detailed strategies and plans that are at the right intersection of ambitious and achievable
+- You have developed detailed strategies and plans that are at the right intersection of ambitious and achievable
 
-**YOUR MISSION  & RESPONSIBILITIES**
+**YOUR MISSION & RESPONSIBILITIES**
 
 Raise $5 to $7 million per year through major gifts of $10,000 to $2,000,000 from ultra-high-net-worth individuals, foundations and corporations, in partnership with COO [Christina Asquith](https://www.linkedin.com/in/christinaasquith/).
 
 ** Strategy and Planning **
 
--   Partner with the COO (Hack Club's current fundraiser) to devise a multi-year philanthropy strategy
+- Partner with the COO (Hack Club's current fundraiser) to devise a multi-year philanthropy strategy
 
--   Steward current donors: create touchpoints, increase their gift size, and ask for introductions
+- Steward current donors: create touchpoints, increase their gift size, and ask for introductions
 
--   Identify new donors, lead on outreach and manage follow up
+- Identify new donors, lead on outreach and manage follow up
 
 ** Fundraising Operations **
 
--   Engage in personal networking and leverage the capacity of other team members and the board to make contacts and engage, secure, and retain donors
+- Engage in personal networking and leverage the capacity of other team members and the board to make contacts and engage, secure, and retain donors
 
--   Work with Hack Club's spreadsheet-based donor management system---simple at first, and we can grow it
+- Work with Hack Club's spreadsheet-based donor management system---simple at first, and we can grow it
 
 ** Communications **
 
--   Craft emails of outreach
+- Craft emails of outreach
 
--   Hire and manage contractors for prospecting, media, donor materials and design work
+- Hire and manage contractors for prospecting, media, donor materials and design work
 
--   Conceptualize and plan trips, dinners, parties, and 1:1s
+- Conceptualize and plan trips, dinners, parties, and 1:1s
 
--   Brainstorm with a small team of design and video contractors to develop storytelling for donors
+- Brainstorm with a small team of design and video contractors to develop storytelling for donors
 
 ** QUALIFICATIONS **
 
+- A demonstrated track record of progressively responsible experience in identifying, cultivating, and soliciting major gifts
 
--   A demonstrated track record of progressively responsible experience in identifying, cultivating, and soliciting major gifts
+- You must have closed on at least one $1 million dollar gift
 
--   You must have closed on at least one $1 million dollar gift
+- Experienced closing gifts from Silicon Valley and the tech industry
 
--   Experienced closing gifts from Silicon Valley and the tech industry
+- Entrepreneurial, self-starting mindset
 
--   Entrepreneurial, self-starting mindset
+- Excellent written and verbal communication skills, with persuasive presentation and negotiation abilities
 
--   Excellent written and verbal communication skills, with persuasive presentation and negotiation abilities
+- Solid computer literacy, from spreadsheets to google workspace. Internally, we work in Slack most of the time
 
--   Solid computer literacy, from spreadsheets to google workspace. Internally, we work in Slack most of the time
+- Initiative in resolving problems and an independent worker, with enthusiasm and an energetic approach to work
 
--   Initiative in resolving problems and an independent worker, with enthusiasm and an energetic approach to work
+- Skilled in developing and maintaining achievable and ambitious financial projections and budgets
 
--   Skilled in developing and maintaining achievable and ambitious financial projections and budgets
+- Exceptional relationship builder
 
--   Exceptional relationship builder
+- Proven superior organizational skills
 
--   Proven superior organizational skills 
+- Exemplary work ethic and professional manner
 
--   Exemplary work ethic and professional manner
-
--   U.S. resident
+- U.S. resident
 
 ** TRAVEL AND LOCATION **
 
--   Willing to travel approximately 6 times per year
+- Willing to travel approximately 6 times per year
 
--   From your home office, you are able to work extended hours and weekends as needed
+- From your home office, you are able to work extended hours and weekends as needed
 
--   Fully Covid-19 vaccinated
+- Fully Covid-19 vaccinated
 
-** TO APPLY: ** [bit.ly/hackclub-vp-donor-engagement-apply](https://bit.ly/hackclub-vp-donor-engagement-apply)
+** TO APPLY: ** [hack.af/vp-donor-engagement](https://hack.af/vp-donor-engagement)
 
 ** TO LEARN MORE,** feel free to contact our search partner, Charlene Wallace, at charlene@charlenewallace.com, for a confidential exploratory conversation.
 

--- a/components/jobs/vp-donor-engagement/jd.mdx
+++ b/components/jobs/vp-donor-engagement/jd.mdx
@@ -1,6 +1,6 @@
 Interested in a dynamic, quickly-growing entrepreneurial nonprofit with teens and technology at its core? Hack Club supports high school coders in 36 states and 22 countries in starting coding clubs, hackathons, and building awesome projects.
 
-As **VP of Donor Engagement** (a new position), you'll shape and advance our philanthropy strategy, and lead on executing it alongside Hack Club's COO, its board, and a team of designers, video, and social media contractors. You'll be working closely with an incredibly talented and unusual creative team of engineers, international journalists, billionaire coders, and teen hackers!
+As **VP, Donor Engagement** (a new position), you'll shape and advance our philanthropy strategy, and lead on executing it alongside Hack Club's COO, its board, and a team of designers, video, and social media contractors. You'll be working closely with an incredibly talented and unusual creative team of engineers, international journalists, billionaire coders, and teen hackers!
 
 To date, we've raised $6 million from a dozen committed donors---including Elon Musk---and the right candidate can leverage our highly-connected network to build a sustainable $5 to $7 million per year donor network with relationship building, storytelling, and collaboration.
 
@@ -112,7 +112,7 @@ Raise $5 to $7 million per year through major gifts of $10,000 to $2,000,000 fro
 
 - Fully Covid-19 vaccinated
 
-** TO APPLY: ** [hack.af/vp-donor-engagement](https://hack.af/vp-donor-engagement)
+** TO APPLY: ** [bit.ly/hackclub-vp-donor-engagement-apply](https://bit.ly/hackclub-vp-donor-engagement-apply)
 
 ** TO LEARN MORE,** feel free to contact our search partner, Charlene Wallace, at charlene@charlenewallace.com, for a confidential exploratory conversation.
 

--- a/next.config.js
+++ b/next.config.js
@@ -112,6 +112,11 @@ const nextConfig = {
         source: '/jobs/bank-ops-assistant/',
         destination: '/jobs/bank-ops-associate/',
         permanent: false
+      },
+      {
+        source: '/jobs/vp-DonorEngagement/',
+        destination: '/jobs/vp-donor-engagement/',
+        permanent: false
       }
     ]
   },

--- a/pages/jobs/index.js
+++ b/pages/jobs/index.js
@@ -154,7 +154,7 @@ const Page = () => (
           <JobListing
             positionName="Vice President, Donor Engagement"
             positionDesc="As VP of Donor Engagement, you’ll shape and advance our philanthropy strategy, and lead on executing it alongside Hack Club’s COO, its board, and a talented team of designers, video, and social media contractors. "
-            positionLink="/jobs/vp-DonorEngagement/"
+            positionLink="/jobs/vp-donor-engagement/"
             color={theme.util.cx('blue')}
             color1={theme.util.cx('purple')}
           />

--- a/pages/jobs/index.js
+++ b/pages/jobs/index.js
@@ -94,7 +94,7 @@ const Page = () => (
         sx={{
           py: [5, 6],
           background:
-            'linear-gradient(90deg, rgba(2,0,36,0.53) 0%, rgba(2,0,36,0.46) 100%), url(/jobs/zephyrGroupPic.JPG)',
+            'linear-gradient(90deg, rgba(2,0,36,0.53) 0%, rgba(2,0,36,0.46) 100%), url(/jobs/zephyr-group-pic.jpg)',
           backgroundSize: 'cover',
           backgroundPosition: 'center',
           textAlign: 'center'

--- a/pages/jobs/vp-donor-engagement.js
+++ b/pages/jobs/vp-donor-engagement.js
@@ -11,7 +11,7 @@ const Page = () => (
       as={Head}
       title="VP of Donor Engagement"
       description="Hack Club is a hiring a VP of Donor Engagement to join our team in Shelburne, Vermont."
-      image="https://workshop-cards.hackclub.com/VP%20of%20Donor%20Engagment%20%40%20Hack%20Club.png?fontSize=160px&brand=HQ"
+      image="https://workshop-cards.hackclub.com/VP%2C%20Donor%20Engagment%20%40%20Hack%20Club.png?fontSize=160px&brand=HQ"
     />
     <ForceTheme theme="light" />
     <Nav />

--- a/pages/jobs/vp-donor-engagement.js
+++ b/pages/jobs/vp-donor-engagement.js
@@ -2,16 +2,16 @@ import { BaseStyles, Box, Container, Heading, Text } from 'theme-ui'
 import Head from 'next/head'
 import Nav from '../../components/nav'
 import Meta from '@hackclub/meta'
-import JobDescription from '../../components/jobs/vp-DonorEngagement/jd.mdx'
+import JobDescription from '../../components/jobs/vp-donor-engagement/jd.mdx'
 import ForceTheme from '../../components/force-theme'
 
 const Page = () => (
   <>
     <Meta
       as={Head}
-      title="VP Donor Engagement"
+      title="VP of Donor Engagement"
       description="Hack Club is a hiring a VP of Donor Engagement to join our team in Shelburne, Vermont."
-      image="https://workshop-cards.hackclub.com/Vp,%20Donor%20Engagment%20%40%20Hack%20Club.png?fontSize=160px&brand=HQ"
+      image="https://workshop-cards.hackclub.com/VP%20of%20Donor%20Engagment%20%40%20Hack%20Club.png?fontSize=160px&brand=HQ"
     />
     <ForceTheme theme="light" />
     <Nav />
@@ -25,7 +25,7 @@ const Page = () => (
     >
       <Container sx={{ textAlign: 'center', color: 'white' }}>
         <Heading as="h1" variant="title" mb={30}>
-        Vice President, Donor Engagement &nbsp;@ Hack&nbsp;Club
+          Vice President, Donor Engagement @&nbsp;Hack&nbsp;Club
         </Heading>
         <Text variant="headline" sx={{ fontWeight: 400 }}>
           New job open as of Feburary 16th, 2022.


### PR DESCRIPTION
This PR makes some minor style fixes to #364:

- Changes the page slug to kebab-case.
  - Currently, the page slug is in camelCase which isn't consistent with the other JD pages & also could be easily mistyped. 
- Renames the image to also use kebab-case like the rest of the images.

🧇 This PR might break something if you already linked this job posting somewhere cause the current link (https://hackclub.com/jobs/vp-DonorEngagement/) will 404 if we don't add a redirect rule in `next.config.js` (Let me know if I should do that!)