### PR TITLE
Add blurb about UI components

### DIFF
--- a/pages/brand.js
+++ b/pages/brand.js
@@ -274,8 +274,12 @@ const Page = ({ css }) => (
         href="https://github.com/hackclub/theme-starter"
         variant="outline"
         mb={3}
+        mr={3}
       >
         Theme Starter on GitHub →
+      </Button>
+      <Button as="a" href="https://github.com/hackclub/css" sx={{ mb: 3 }}>
+        Theme CSS on GitHub →
       </Button>
     </Container>
     <Footer />

--- a/pages/brand.js
+++ b/pages/brand.js
@@ -237,8 +237,9 @@ const Page = ({ css }) => (
       </Box>
       <Heading variant="headline">Icons</Heading>
       <Text variant="subtitle" sx={{ a: { variant: 'styles.a' }, mb: 3 }}>
-        We have a custom iconset, published as{' '}
-        <a href="https://github.com/hackclub/icons">@hackclub/icons</a>.
+        <p>We have a custom iconset, published as{' '}
+          <a href="https://github.com/hackclub/icons">@hackclub/icons</a>.
+        </p>
       </Text>
       <Flex sx={{ flexWrap: 'wrap', svg: { fill: 'muted', mr: 3, mb: 3 } }}>
         {[
@@ -262,6 +263,9 @@ const Page = ({ css }) => (
         Explore Hack Club Icons →
       </Button>
       <Heading variant="headline">UI components</Heading>
+      <Text variant="subtitle" sx={{ a: { variant: 'styles.a' }, mb: 3 }}>
+        <p>Want to make a Hack Club themed site? Use our pre-made CSS and UI components to hackify your site.</p>
+      </Text>
       <Button as="a" href="https://theme.hackclub.com/" sx={{ mr: 3, mb: 3 }}>
         Explore Hack Club Theme →
       </Button>

--- a/pages/brand.js
+++ b/pages/brand.js
@@ -236,10 +236,13 @@ const Page = ({ css }) => (
         </Text>
       </Box>
       <Heading variant="headline">Icons</Heading>
-      <Text variant="subtitle" sx={{ a: { variant: 'styles.a' }, mb: 3 }}>
-        <p>We have a custom iconset, published as{' '}
-          <a href="https://github.com/hackclub/icons">@hackclub/icons</a>.
-        </p>
+      <Text
+        as="p"
+        variant="subtitle"
+        sx={{mb: 3}}
+      >
+        We have a custom iconset, published as{' '}
+        <A href="https://github.com/hackclub/icons">@hackclub/icons</A>.
       </Text>
       <Flex sx={{ flexWrap: 'wrap', svg: { fill: 'muted', mr: 3, mb: 3 } }}>
         {[
@@ -264,8 +267,12 @@ const Page = ({ css }) => (
         Explore Hack Club Icons →
       </Button>
       <Heading variant="headline">UI components</Heading>
-      <Text variant="subtitle" sx={{ a: { variant: 'styles.a' }, mb: 3 }}>
-        <p>Want to make a Hack Club themed site? Use our pre-made CSS and UI components to hackify your site.</p>
+      <Text
+        as="p"
+        variant="subtitle"
+        sx={{ a: { variant: 'styles.a' }, mb: 3 }}
+      >
+        Want to make a Hack Club themed site? Use our pre-made CSS and UI components to hackify your site.
       </Text>
       <Button
         as="a"

--- a/pages/brand.js
+++ b/pages/brand.js
@@ -259,6 +259,7 @@ const Page = ({ css }) => (
         as="a"
         href="https://icons.hackclub.com"
         sx={{ mt: 3, mb: [4, 5] }}
+        variant="outline"
       >
         Explore Hack Club Icons →
       </Button>
@@ -266,19 +267,29 @@ const Page = ({ css }) => (
       <Text variant="subtitle" sx={{ a: { variant: 'styles.a' }, mb: 3 }}>
         <p>Want to make a Hack Club themed site? Use our pre-made CSS and UI components to hackify your site.</p>
       </Text>
-      <Button as="a" href="https://theme.hackclub.com/" sx={{ mr: 3, mb: 3 }}>
+      <Button
+        as="a"
+        href="https://theme.hackclub.com/"
+        sx={{ mr: 3, mb: 3 }}
+        variant="outline"
+      >
         Explore Hack Club Theme →
       </Button>
       <Button
         as="a"
         href="https://github.com/hackclub/theme-starter"
-        variant="outline"
         mb={3}
         mr={3}
+        variant="outline"
       >
         Theme Starter on GitHub →
       </Button>
-      <Button as="a" href="https://github.com/hackclub/css" sx={{ mb: 3 }}>
+      <Button
+        as="a"
+        href="https://github.com/hackclub/css"
+        sx={{ mb: 3 }}
+        variant="outline"
+      >
         CSS Theme on GitHub →
       </Button>
     </Container>

--- a/pages/brand.js
+++ b/pages/brand.js
@@ -270,7 +270,7 @@ const Page = ({ css }) => (
       <Text
         as="p"
         variant="subtitle"
-        sx={{ a: { variant: 'styles.a' }, mb: 3 }}
+        sx={{ mb: 3 }}
       >
         Want to make a Hack Club themed site? Use our pre-made CSS and UI components to hackify your site.
       </Text>

--- a/pages/brand.js
+++ b/pages/brand.js
@@ -279,7 +279,7 @@ const Page = ({ css }) => (
         Theme Starter on GitHub →
       </Button>
       <Button as="a" href="https://github.com/hackclub/css" sx={{ mb: 3 }}>
-        Theme CSS on GitHub →
+        CSS Theme on GitHub →
       </Button>
     </Container>
     <Footer />

--- a/pages/brand.js
+++ b/pages/brand.js
@@ -239,7 +239,7 @@ const Page = ({ css }) => (
       <Text
         as="p"
         variant="subtitle"
-        sx={{mb: 3}}
+        sx={{ mb: 3 }}
       >
         We have a custom iconset, published as{' '}
         <A href="https://github.com/hackclub/icons">@hackclub/icons</A>.


### PR DESCRIPTION
Add small blurb about UI components, since right now it's empty.

Also add button to our CSS GitHub. Once we make the forkable static example, we may want to redo this section. In the meantime, I think this is an improvement.

<img width="940" alt="Screen Shot 2022-03-09 at 1 52 11 PM" src="https://user-images.githubusercontent.com/621904/157511176-e54b32c9-a719-4a66-bf3d-e8207459f7dd.png">