### PR TITLE
Optimize header image on Jobs page

### DIFF
--- a/pages/jobs/index.js
+++ b/pages/jobs/index.js
@@ -115,7 +115,7 @@ const Page = () => (
         >
           <Image
             src={zephyrPic}
-            alt="Hack Clubbers Hack Clubbing"
+            alt="Hack Clubbers hacking during the Hacker Zephyr trip"
             layout="fill"
             objectFit="cover"
           />

--- a/pages/jobs/index.js
+++ b/pages/jobs/index.js
@@ -8,6 +8,8 @@ import Nav from '../../components/nav'
 import Footer from '../../components/footer'
 import theme from '../../lib/theme'
 import Link from 'next/link'
+import Image from 'next/image'
+import zephyrPic from '../../public/jobs/zephyr-group-pic.jpg'
 
 const Sheet = styled(Card)`
   position: relative;
@@ -94,12 +96,30 @@ const Page = () => (
         sx={{
           py: [5, 6],
           background:
-            'linear-gradient(90deg, rgba(2,0,36,0.53) 0%, rgba(2,0,36,0.46) 100%), url(/jobs/zephyr-group-pic.jpg)',
+            'linear-gradient(90deg, rgba(2,0,36,0.53) 0%, rgba(2,0,36,0.46) 100%)',
           backgroundSize: 'cover',
           backgroundPosition: 'center',
-          textAlign: 'center'
+          textAlign: 'center',
+          position: 'relative'
         }}
       >
+        <Box
+          sx={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            bottom: 0,
+            right: 0,
+            zIndex: -1
+          }}
+        >
+          <Image
+            src={zephyrPic}
+            alt="Hack Clubbers Hack Clubbing"
+            layout="fill"
+            objectFit="cover"
+          />
+        </Box>
         <Container>
           <Heading
             as="h1"


### PR DESCRIPTION
using `<Image>` 'n stuff

previously:
<img width="964" alt="Screen Shot 2022-03-21 at 2 07 41 PM" src="https://user-images.githubusercontent.com/34525547/159345284-20288176-d5e1-401c-8670-5c61d6884424.png">
