### PR TITLE
Increase repos to 50 from `contribute` endpoint

### DIFF
--- a/pages/api/contribute.js
+++ b/pages/api/contribute.js
@@ -11,7 +11,7 @@ export default async function handler(_, res) {
   const { organization } = await graphql(`
     query orgQuery($login: String!) {
       organization(login: $login) {
-        repositories(first: 20, privacy: PUBLIC, orderBy: {
+        repositories(first: 50, privacy: PUBLIC, orderBy: {
           field: PUSHED_AT, direction: DESC
         }){
           nodes {


### PR DESCRIPTION
We can't filter out repositories with 0 issues from the GitHub GraphQL API, so we are limiting how many we show from our `contribute` JS. 