### PR TITLE
Improve contrast on Slack join form

### DIFF
--- a/components/slack/header.js
+++ b/components/slack/header.js
@@ -49,7 +49,7 @@ const Content = () => (
     <SlideUp sx={{ zIndex: 5, display: 'flex', alignItems: 'center' }}>
       <JoinForm
         sx={{
-          variant: 'cards.translucent',
+          bg: 'smoke',
           position: 'relative',
           zIndex: 3
         }}

--- a/pages/slack.js
+++ b/pages/slack.js
@@ -1,14 +1,4 @@
-import {
-  Badge,
-  Box,
-  Card,
-  Container,
-  Heading,
-  Grid,
-  Image,
-  Link,
-  Text
-} from 'theme-ui'
+import { Badge, Box, Card, Container, Heading, Grid, Text } from 'theme-ui'
 import { keyframes } from '@emotion/react'
 import Head from 'next/head'
 import NextLink from 'next/link'
@@ -18,7 +8,6 @@ import ForceTheme from '../components/force-theme'
 import Icon from '../components/icon'
 import Stat from '../components/stat'
 import Footer from '../components/footer'
-import SlideUp from '../components/slide-up'
 import Header from '../components/slack/header'
 import SlackEvents from '../components/slack/slack-events'
 import { getCount } from '../pages/api/channels/count-to-a-million'


### PR DESCRIPTION
Before:
<img width="1201" alt="Screen Shot 2022-04-04 at 00 22 39" src="https://user-images.githubusercontent.com/72365100/161496777-79cc9556-4267-46a3-b07f-3e378bb77cc7.png">

Now:
<img width="1175" alt="Screen Shot 2022-04-04 at 00 32 37" src="https://user-images.githubusercontent.com/72365100/161496784-3ffd3a39-e04c-40f9-863b-b849796c052c.png">

(I also removed the unused imports on `pages/slack.js`.)
