### PR TITLE
Reduce time to join Slack

### DIFF
--- a/pages/api/join.js
+++ b/pages/api/join.js
@@ -57,18 +57,8 @@ export default async function handler(req, res) {
     }
   }
 
-  await joinTable.create({
-    'Full Name': data.name,
-    'Email Address': data.email,
-    Student: data.educationLevel != 'tertiary' ? true : false,
-    Reason: data.reason,
-    Invited: open,
-    Club: data.club ? data.club : '',
-    IP: req.headers['x-forwarded-for'] || req.socket.remoteAddress
-  })
-
   if (open) {
-    let result = await postData(
+    postData(
       'https://toriel.hackclub.com/slack-invite',
       {
         email: data.email,
@@ -81,7 +71,6 @@ export default async function handler(req, res) {
       },
       { authorization: `Bearer ${process.env.TORIEL_KEY}` }
     )
-    console.log(result)
     res.json({ status: 'success', message: 'You’ve been invited to Slack!' })
   } else {
     res.json({

--- a/pages/api/join.js
+++ b/pages/api/join.js
@@ -7,7 +7,6 @@ const joinTable = new AirtablePlus({
 })
 
 async function postData(url = '', data = {}, headers = {}) {
-  console.log(data)
   const response = await fetch(url, {
     method: 'POST',
     mode: 'cors',

--- a/pages/api/join.js
+++ b/pages/api/join.js
@@ -56,7 +56,7 @@ export default async function handler(req, res) {
     }
   }
   
-  promises = []
+  let promises = []
   
   promises.push(joinTable.create({
     'Full Name': data.name,

--- a/pages/api/join.js
+++ b/pages/api/join.js
@@ -55,9 +55,21 @@ export default async function handler(req, res) {
       })
     }
   }
-
+  
+  promises = []
+  
+  promises.push(joinTable.create({
+    'Full Name': data.name,
+     'Email Address': data.email,
+     Student: data.educationLevel != 'tertiary' ? true : false,
+     Reason: data.reason,
+     Invited: open,
+     Club: data.club ? data.club : '',
+     IP: req.headers['x-forwarded-for'] || req.socket.remoteAddress
+  }))
+  
   if (open) {
-    postData(
+    promises.push(postData(
       'https://toriel.hackclub.com/slack-invite',
       {
         email: data.email,
@@ -69,9 +81,11 @@ export default async function handler(req, res) {
         userAgent: req.headers['user-agent'],
       },
       { authorization: `Bearer ${process.env.TORIEL_KEY}` }
-    )
+    ))
+    await Promise.all(promises)
     res.json({ status: 'success', message: 'You’ve been invited to Slack!' })
   } else {
+    await Promise.all(promises)
     res.json({
       status: 'success',
       message: 'Your request will be reviewed soon.'


### PR DESCRIPTION
This is slightly opinionated, @maxwofford I'd like your approval before merging. Merging this PR will deprecate the Join Requests Table in Airtable and will also not await the post request to Toriel (as we weren't doing anything with that response data anyway)