### PR TITLE
Copy pass on Bank's marketing page

### DIFF
--- a/components/bank/everything.js
+++ b/components/bank/everything.js
@@ -119,8 +119,8 @@ export default function Everything({ fee, partner = false }) {
                   hoverline
                 >
                   fiscal sponsor
-                </Link>{' '}
-                for your&nbsp;project. Industry standard varies between 7-14%
+                </Link>.
+                Fiscal sponsorship fees typically vary between 7-14%
                 of&nbsp;revenue. Hack Club is a 501(c)(3) nonprofit.
               </Text>
             </Container>

--- a/components/bank/features.js
+++ b/components/bank/features.js
@@ -11,7 +11,7 @@ export default function Features({ partner = false }) {
         <br />
         <br />
         <Text sx={{ color: 'muted', maxWidth: '48', fontSize: 28 }}>
-          Invoice sponsors, issue debit cards to your team, and view history.
+          Invoice sponsors, issue debit cards to your team, and view transaction history.
           <br />
           Ongoing support so you can focus on organizing, not the paperwork.
         </Text>
@@ -172,20 +172,20 @@ export default function Features({ partner = false }) {
             />
           )}
           <Module
-            icon="sticker"
-            name="Sticker Mule"
+            icon="private-outline"
+            name="1Password"
             body={
               <>
-                Get up to $400 in{' '}
+                $100 in free{' '}
                 <Link
-                  href="https://www.stickermule.com"
+                  href="https://1password.com/"
                   color="smoke"
                   hoverline
                   target="_blank"
                 >
-                  Sticker Mule
+                  1Password
                 </Link>{' '}
-                credit for custom swag.
+                credit to keep your team's passwords secure.
               </>
             }
           />

--- a/components/bank/form.js
+++ b/components/bank/form.js
@@ -59,8 +59,8 @@ export default function BankApplyForm() {
           Apply for Hack Club Bank
         </Text>
         <Text sx={{ fontSize: 18, mb: 2 }}>
-          Hack Club Bank is open to all Hack Clubs, hackathons, and student-led
-          nonprofits. There are three steps to getting on Hack Club Bank:
+          Hack Club Bank is open to all Hack Clubs, hackathons, and charitable
+          organizations. There are three steps to getting on Hack Club Bank:
           <ol>
             <li>Fill out this form</li>
             <li>
@@ -82,20 +82,20 @@ export default function BankApplyForm() {
       </Flex>
       <Base method="POST" action="/api/bank-apply">
         <Text variant="headline" sx={{ color: 'primary' }}>
-          Your Project
+          Your Organization
         </Text>
         <Divider sx={{ borderColor: 'slate', mt: -2 }} />
         <Field
-          label="Project name"
+          label="Organization name"
           name="eventName"
           placeholder="Windy City Hacks"
-          helperText="What's the name of your event or project?"
+          helperText="What's the name of your organization?"
           value={values.eventName}
           onChange={handleChange}
           required
         />
         <Field
-          label="Project website"
+          label="Organization website"
           name="eventWebsite"
           placeholder="https://hackclub.com"
           type="url"
@@ -104,7 +104,7 @@ export default function BankApplyForm() {
           onChange={handleChange}
         />
         <Field
-          label="Project Location"
+          label="Organization location"
           name="eventLocation"
           placeholder="San Francisco, CA"
           type="text"
@@ -142,7 +142,7 @@ export default function BankApplyForm() {
           htmlFor="eventDescription"
           sx={{ color: 'smoke', fontSize: 18, my: 2 }}
         >
-          Tell us about your project!
+          Tell us about your organization!
           <Textarea
             name="eventDescription"
             sx={{ bg: 'dark', my: 1 }}

--- a/components/bank/landing.js
+++ b/components/bank/landing.js
@@ -50,7 +50,7 @@ export default function Landing({ showButton, eventsCount }) {
                     }
                   }}
                 >
-                  <Underline>Make your ideas real</Underline> with
+                  <Underline>Become a 501(c)(3) nonprofit</Underline> with
                   Hack&nbsp;Club&nbsp;Bank.
                 </Heading>
                 <Container variant="copy">

--- a/components/bank/signup.js
+++ b/components/bank/signup.js
@@ -65,7 +65,7 @@ export default function Signup() {
   return (
     <Base method="get" action="/bank/apply" onSubmit={handleSubmit}>
       <Field
-        label="Project name"
+        label="Organization name"
         name="eventName"
         placeholder="Windy City Hacks"
         value={values.eventName}

--- a/components/bank/start.js
+++ b/components/bank/start.js
@@ -40,8 +40,7 @@ export default function Start() {
           </Heading>
           <Container variant="narrow" sx={{ color: 'muted' }}>
             <Text variant="lead">
-              Open to all registered Hack Clubs, hackathons, and your next
-              amazing project.
+              Open to all registered Hack Clubs, hackathons, and charitable organizations.
             </Text>
           </Container>
         </Container>
@@ -58,7 +57,7 @@ export default function Start() {
               }}
             >
               <Text variant="heading" sx={{ fontSize: 24, lineHeight: 2 }}>
-                Your project
+                Your organization
               </Text>
               <Signup />
             </Card>

--- a/components/bank/timeline.js
+++ b/components/bank/timeline.js
@@ -122,7 +122,7 @@ export default function RealTimeline() {
     <Timeline px={3}>
       <Step
         icon="send"
-        name="Submit an application telling us about your project"
+        name="Submit an application for your organization"
         duration="Step 1"
         href="/bank/apply"
       />


### PR DESCRIPTION
This is a copy pass on Bank's marketing page. I made a few small changes:

- Lead with the fact that Bank makes your org a 501(c)(3). I did some user interviews and this was the number 1 thing I was hearing from people.
- Swap Sticker Mule for 1Password, since the Sticker Mule promotion is no longer working for most organizations
- Use the word "organization" instead of "project" when referring to fiscally sponsored groups

Please feel free to fix any issues with the code, or push back on any of the changes I made. Thank you!

cc @maxwofford 