### PR TITLE
Patch CVE-2021-3918 json-schema Prototype Pollution

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2745,8 +2745,8 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
-json-schema@0.2.3:
-  version "0.2.3"
+json-schema@0.4.0:
+  version "0.4.0"
   resolved "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
   integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
 


### PR DESCRIPTION
json-schema is vulnerable to Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
CVE-2021-3918
```
CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
Severity Critical 9.8 / 10
```

upgrade json-schema to version 0.4.0:
```
json-schema@^0.4.0:
  version "0.4.0"
```