### PR TITLE
Remove "Donate" from the Nav bar

### DIFF
--- a/components/nav.js
+++ b/components/nav.js
@@ -147,9 +147,6 @@ const Navigation = props => (
     <NextLink href="/hackathons" passHref>
       <Link>Hackathons</Link>
     </NextLink>
-    <NextLink href="/donate" passHref>
-      <Link>Donate</Link>
-    </NextLink>
   </NavBar>
 )
 


### PR DESCRIPTION
I talked about this with @maxwofford on the flight to SF, I think the nav bar has became a bit cluttered and we could probably remove the donate page because it isn't student-facing and doesn't get much traffic.