### PR TITLE
Fix announcement on hackathons/landing

### DIFF
--- a/components/hackathons/landing.js
+++ b/components/hackathons/landing.js
@@ -28,7 +28,7 @@ export default function Landing() {
             color="primary"
             sx={{
               position: 'absolute',
-              top: [2, 4],
+              top: [-2, 4],
               left: '0',
               right: '0',
               mx: 'auto',

--- a/components/hackathons/landing.js
+++ b/components/hackathons/landing.js
@@ -28,6 +28,7 @@ export default function Landing() {
             color="primary"
             sx={{
               position: 'absolute',
+              top: [2, 4],
               left: '0',
               right: '0',
               mx: 'auto',

--- a/components/hackathons/landing.js
+++ b/components/hackathons/landing.js
@@ -28,7 +28,6 @@ export default function Landing() {
             color="primary"
             sx={{
               position: 'absolute',
-              top: ['-10px', '-120px'],
               left: '0',
               right: '0',
               mx: 'auto',


### PR DESCRIPTION
I noticed the `<Announcement>` in the `<Landing>` component of `/hackathons` showing up differently for me on different browsers. Turns out, it would not show up, or would only partially show up, on smaller screen sizes. For example, you wouldn't see it on Chrome or Firefox on the MBA 13" with default scaling unless you full-screened.

So I just removed the top margin on `<Announcement>` :sphere:

It makes it show up on more screens & is maybe even a better spot altogether, next to the big card :))

I'm sure there's a better fix than this, but hey: at least it works!