### PR TITLE
Fix the link for the Community Newsletter

### DIFF
--- a/pages/opensource.js
+++ b/pages/opensource.js
@@ -161,7 +161,7 @@ const Page = ({ repos }) => (
         />
          <BankProject
           name="Community Newsletter"
-          url="https://hackclub.com/newsletter"
+          url={`https://github.com/hackclub/newsletters`}
         />
         <BankProject name="Meetings" url={`https://meetings.hackclub.com`} />
       </Grid>


### PR DESCRIPTION
Noticed I forgot to include the github link in the last PR. This matches the rest of the links in the section and repo