### PR TITLE
Remove announcement banner from hackathons page

### DIFF
--- a/components/hackathons/landing.js
+++ b/components/hackathons/landing.js
@@ -4,7 +4,7 @@ import ScrollHint from '../scroll-hint'
 import Image from 'next/image'
 import hero from '../../public/hackathons/assemble.JPG'
 import Icon from '../icon'
-import Announcement from '../announcement'
+
 export default function Landing() {
   return (
     <>
@@ -20,22 +20,6 @@ export default function Landing() {
             width: '100%'
           }}
         >
-          <Announcement
-            copy="Run an in-person hackathon this semester"
-            caption="$500 grants and more, with support from Hack Club and FIRST."
-            href="/hackathons/grant"
-            iconLeft="event-code"
-            color="primary"
-            sx={{
-              position: 'absolute',
-              top: [-2, 4],
-              left: '0',
-              right: '0',
-              mx: 'auto',
-              width: 'fit-content',
-              height: 'fit-content'
-            }}
-          />
           <Box
             sx={{
               zIndex: 999,


### PR DESCRIPTION
The positioning doesn't look quite right. Is it cool if we remove it until we figure something out around the positioning?