### PR TITLE
Create IT Admins page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -157,6 +157,10 @@ const nextConfig = {
         destination: '/content/covid19/'
       },
       {
+        source: '/it-admins/',
+        destination: '/content/it-admins/'
+      },
+      {
         source: '/sunsetting-som/',
         destination: '/content/sunsetting-som/'
       },

--- a/pages/content/it-admins.mdx
+++ b/pages/content/it-admins.mdx
@@ -1,0 +1,34 @@
+import Letterhead from '../../components/letterhead'
+import Announcement from '../../components/announcement'
+
+<Letterhead
+title="Hack Club for IT Administrators"
+img="https://workshop-cards.hackclub.com/For IT Admins.png?brand=HQ&fontSize=300px"
+path="filters.mdx">
+
+If you are reading this, you are probably an IT administrator at your organization. **Here's a quick overview of what we need from you.**
+
+Please whitelist or unblock the following domains:
+- `*.hackclub.com` - Hack Club's primary domain, hosts workshops, tools and other content
+- `hack.af` - link shortener used for miscellanous links
+- `*.replit.com`, `*.cdn.replit.com`, and `*.repl.co` - Replit, a browser-based IDE used for workshops
+- `*.github.com`, `github.dev` - GitHub, an industry standard for code hosting and collaboration
+- `hackclub.slack.com` - Hack Club's primary communication platform
+
+Feel free to read on for more details and potential alternatives.
+
+## Hack Club Sites
+If you are unable to whitelist all subdomains, please whitelist the following:
+- `hackclub.com`
+- `workshops.hackclub.com`
+- `editor.sprig.hackclub.com`
+- `sprig.hackclub.com`
+
+## GitHub
+Besides the typical HTTP(S) ports, ports 22 and 9418 need to be open for SSH and Git respectively.
+
+## Replit
+Replit provides their own [toolkit](https://docs.replit.com/teams-edu/it-administrators-toolkit) for IT administrators with further options for providing student access to Replit, including a firewalled domain.
+
+Thank you for supporting your students and their interests. If you have any questions, please reach out to us at [clubs@hackclub.com](mailto:clubs@hackclub.com) and we'd be happy to address your concerns.
+</Letterhead>


### PR DESCRIPTION
A few people have asked in #leaders about how to handle blocked sites that they need for their clubs, so I thought it may be useful for leaders to have a page that they can send to their sysadmins to get those sites unblocked.

I'm not entirely sure if this should be here or with the workshops... I may not have covered all the sites clubs may need so please feel free to review and edit :) The copy feels a little awkward but I think it captures the general gist of what I'm trying to say. This also did not take very long so I'm cool w/ closing if this isn't helpful. 

Slack thread: https://hackclub.slack.com/archives/C02PA5G01ND/p1663626700154389