### PR TITLE
that -> who

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -228,7 +228,7 @@ function Page({
                   </Text>
                   teen hackers
                 </Text>
-                from around the world that code together
+                from around the world who code together
               </Text>
               <Button variant="ctaLg" as="a" href="/slack" mt={[3, 0, 0]}>
                 Join our community


### PR DESCRIPTION
I'm back with the minor grammar fixes! Changed that to who, which is more appropriate for referring to groups of people.