### PR TITLE
Bank API: Migrate to underscored Org category

### DIFF
--- a/pages/opensource.js
+++ b/pages/opensource.js
@@ -239,7 +239,7 @@ export async function getStaticProps() {
 
   const transparentAccounts = (await fetch(
     'https://bank.hackclub.com/api/v3/organizations'
-  ).then(res => res.json())).filter(account => account.category === 'hack club hq')
+  ).then(res => res.json())).filter(account => account.category.replaceAll(' ', '_') === 'hack_club_hq')
 
   return { props: { repos, transparentAccounts }, revalidate: 30 }
 }


### PR DESCRIPTION
Due to a bug in https://github.com/hackclub/bank/pull/3394, categories were not underscored as intended. Since the Transparency API doesn't have versioning set up yet, a breaking change to the API (https://github.com/hackclub/bank/pull/3402) will be released on Tuesday Jan 10th, 2023. The change will underscore all categories returned by the API (as declared in the docs https://bank.hackclub.com/docs/api/v3/schemas/Organization).

> 'hack club hq' will become 'hack_club_hq'

This PR will maintain capability as this breaking change rolls out.