### PR TITLE
yeet overflow bug

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -616,7 +616,6 @@ function Page({
                 as="p"
                 sx={{
                   fontSize: ['18px', '24px', '32px'],
-                  width: ['95vw', '66vw'],
                   margin: 'auto',
                   pt: 2,
                   pb: [1, 0, 0],

--- a/pages/index.js
+++ b/pages/index.js
@@ -828,7 +828,6 @@ function Page({
                   as="p"
                   sx={{
                     fontSize: ['18px', '24px', '32px'],
-                    width: ['100%', '66vw'],
                     margin: 'auto',
                     pt: 2,
                     textAlign: 'center'


### PR DESCRIPTION
removed hardcoded widths on text to have it default to 100% of its container

before:
![image](https://user-images.githubusercontent.com/84192816/222981930-b259563a-6dd9-4d17-b6da-739fb1abdf32.png)
after:
![image](https://user-images.githubusercontent.com/84192816/222981943-94432c7b-3fc3-4ad5-af17-611f5dc162de.png)
