### PR TITLE
Update fiscal sponsor fee wording

### DIFF
--- a/components/bank/everything.js
+++ b/components/bank/everything.js
@@ -121,7 +121,7 @@ export default function Everything({ fee, partner = false }) {
                 >
                   fiscal sponsor
                 </Link>
-                . Fiscal sponsorship fees typically vary between 7-14%
+                . Other fiscal sponsors' fees typically vary between 7-14%
                 of&nbsp;revenue. Hack Club is a 501(c)(3) nonprofit.
               </Text>
             </Container>


### PR DESCRIPTION
Clarify fiscal sponsorship fees.

![image](https://user-images.githubusercontent.com/76178582/223916456-8978cf14-75c2-4c11-aeaf-e601e0d86127.png) | ➡️ | ![image](https://user-images.githubusercontent.com/76178582/223916495-502102d2-b451-4b63-bbad-ae04d2f0922e.png)
----|---|-----


Slack context: https://hackclub.slack.com/archives/CN523HLKW/p1678335291899849
> sorry for all the questions! when this says “Fiscal sponsorship fees typically vary between 7-14% of revenue”, does it mean “HCB charges between 7 and 14 percent”, or “a typical fiscal sponsor charges between 7 and 14 percent”?