### PR TITLE
Fix PVSA link in Bank's features section

### DIFF
--- a/components/bank/features.js
+++ b/components/bank/features.js
@@ -144,7 +144,7 @@ export default function Features({ partner = false }) {
               <>
                 Issue the{' '}
                 <Link
-                  href="https://www.presidentialserviceawards.gov"
+                  href="https://presidentialserviceawards.gov"
                   color="smoke"
                   hoverline
                   target="_blank"


### PR DESCRIPTION
[No need](https://presidentialserviceawards.gov) for the `www` prefix, and it seems to be throwing a 500 (server) error when using [that subdomain](https://www.presidentialserviceawards.gov) anyway.