### PR TITLE
Hide "Singapore" on narrow mobile devices to avoid confusion

### DIFF
--- a/components/bank/landing.js
+++ b/components/bank/landing.js
@@ -115,7 +115,7 @@ export default function Landing({ showButton, eventsCount }) {
           </Box>
           <ScrollHint />
         </Box>
-        <Box sx={{ position: 'absolute', bottom: 3, right: 2 }}>
+        <Box sx={{ position: 'absolute', bottom: 3, right: 2, display: ["none", "block"] }}>
           <Badge
             variant="pill"
             sx={{


### PR DESCRIPTION
<img width="476" alt="image" src="https://github.com/hackclub/site/assets/76178582/9629c1ef-ddaf-4f37-9059-c2708c50eb14">
