### PR TITLE
Fixes #911

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ public/sitemap.xml
 .vercel
 .vscode
 yarn-error.log
+bun.lockb

--- a/components/hcb/directory/card.js
+++ b/components/hcb/directory/card.js
@@ -111,8 +111,8 @@ export const OrganizationCard = ({
         }}
       >
         {badges.map((badge, i) => (
-          <Tooltip.W key={i} text={badge.label}>
-            <span class="tooltipped">
+          <Tooltip.W key={i} text={badge.label} id={badge.id}>
+            <span class={`tooltipped-${badge.id}`}>
               <Badge badge={badge} />
             </span>
           </Tooltip.W>

--- a/components/hcb/tooltip.js
+++ b/components/hcb/tooltip.js
@@ -8,9 +8,8 @@ const addClassNameToChildren = (children, className) =>
   )
 
 const tooltip = direction =>
-  function Tooltip({ children, text }) {
+  function Tooltip({ children, text, id }) {
     const escapedText = text.replace(/'/g, "\\'")
-
     const directionalStyles = {
       e: `
             left: 100%;
@@ -41,12 +40,12 @@ const tooltip = direction =>
 
     return (
       <>
-        <style>{`.tooltipped {
+        <style>{`.tooltipped${id ? '-' + id : ''} {
                 position: relative;
             }
             
             @media (min-width: 56em) {
-                .tooltipped:after {
+                .tooltipped${id ? '-' + id : ''}:after {
                     background-color: rgba(31, 45, 61, 0.875);
                     border-radius: 0.5rem;
                     box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.0625),
@@ -74,15 +73,15 @@ const tooltip = direction =>
             
                 }
             
-                .tooltipped:hover:after,
-                .tooltipped:active:after,
-                .tooltipped:focus:after {
+                .tooltipped${id ? '-' + id : ''}:hover:after,
+                .tooltipped${id ? '-' + id : ''}:active:after,
+                .tooltipped${id ? '-' + id : ''}:focus:after {
                     opacity: 1;
                     z-index: 9000000;
                     backdrop-filter: blur(2px);
                 }
             
-                .tooltipped:after {
+                .tooltipped${id ? '-' + id : ''}:after {
                     ${directionalStyles}
                 }
             }`}</style>

--- a/pages/hcb/climate/index.js
+++ b/pages/hcb/climate/index.js
@@ -672,7 +672,6 @@ export default function ClimatePage({ rawOrganizations, pageRegion }) {
                 ))}
 
                 {badges.forOrg(modalOrganization).map((badge, i) => {
-                  console.log('badge', badge.label)
                   return (
                     <Tooltip.N key={i} text={badge.tooltip} id={badge.id}>
                       <span class={`tooltipped-${badge.id}`}>

--- a/pages/hcb/climate/index.js
+++ b/pages/hcb/climate/index.js
@@ -669,13 +669,16 @@ export default function ClimatePage({ rawOrganizations, pageRegion }) {
                   </ThemeBadge>
                 ))}
 
-                {badges.forOrg(modalOrganization).map((badge, i) => (
-                  <Tooltip.N key={i} text={badge.tooltip}>
-                    <span class="tooltipped">
-                      <Badge badge={badge} />
-                    </span>
-                  </Tooltip.N>
-                ))}
+                {badges.forOrg(modalOrganization).map((badge, i) => {
+                  console.log('badge', badge.label)
+                  return (
+                    <Tooltip.N key={i} text={badge.tooltip} id={badge.id}>
+                      <span class={`tooltipped-${badge.id}`}>
+                        <Badge badge={badge} />
+                      </span>
+                    </Tooltip.N>
+                  )
+                })}
               </Flex>
 
               <Flex


### PR DESCRIPTION
Fixed the tooltips sharing CSS content property through .tooltip by appending the badge ID as a suffix to the `.tooltipped` class in order to have unique `content` CSS values for each badge.

Fixes issue #911 