### PR TITLE
Update hackathon grant expiration date

### DIFF
--- a/pages/hackathons/grant.js
+++ b/pages/hackathons/grant.js
@@ -192,14 +192,14 @@ const HackathonGrant = () => {
 
           <Grid columns={[1, 1, 2, 2]} gap={4}>
             <Requirement
-              title="Running this year"
+              title="Running through next year"
               checkmark="clock-fill"
               background="https://icons.hackclub.com/api/icons/0x212025/glyph:clock.svg"
               size="36"
             >
               We want to bring back high schooler-led events around the world,
               so we're only offering this grant for high school hackathons that
-              take place this year (until December 31st).
+              take place throughout 2024 (until December 31st).
               <br />
               <br />
               <Text
@@ -209,7 +209,7 @@ const HackathonGrant = () => {
                 }}
               >
                 This is not an annual program and has only been renewed until
-                the end of this year.
+                the end of 2024.
               </Text>
             </Requirement>
             <Requirement


### PR DESCRIPTION
Updated grant's expiration date on the site to Dec 31st 2024. Feel free to edit text to clarify it more if needed!

Context:
![image](https://github.com/hackclub/site/assets/38901010/b85b1a81-90da-488c-9189-e8e6d51667ee)

Updated text:
![image](https://github.com/hackclub/site/assets/38901010/af316539-46b6-4a33-ac1d-e3336c907f18)
