### PR TITLE
Make the 404 page glitch effect choppy with a non-continuous timing function

### DIFF
--- a/pages/404.js
+++ b/pages/404.js
@@ -160,12 +160,12 @@ const Blinking = styled(Heading)`
   &:after {
     left: 2px;
     text-shadow: -2px 0 ${theme.colors.red};
-    animation: ${animation1} 2s infinite linear alternate-reverse;
+    animation: ${animation1} 2s infinite steps(2, jump-end) alternate-reverse;
   }
   &:before {
     left: -2px;
     text-shadow: -2px 0 ${theme.colors.cyan};
-    animation: ${animation2} 4s infinite linear alternate-reverse;
+    animation: ${animation2} 4s infinite steps(2, jump-end) alternate-reverse;
   }
 `
 


### PR DESCRIPTION
I landed on the 404 page accidentally, then saw the glitch effect and thought it was cool. I didn't like how smooth it was, so I tinkered with the CSS to make it choppier. 