### PR TITLE
Added jams, removed editor.sprig.hackcub.com

### DIFF
--- a/pages/content/it-admins.mdx
+++ b/pages/content/it-admins.mdx
@@ -24,7 +24,7 @@ If you are unable to whitelist all subdomains, please whitelist the following:
 
 - `hackclub.com`
 - `workshops.hackclub.com`
-- `editor.sprig.hackclub.com`
+- `jams.hackclub.com`
 - `sprig.hackclub.com`
 
 ## GitHub


### PR DESCRIPTION
Added jams, removed editor.sprig.hackclub.com

Question, should we add this for blot:?


- `blot.hackclub.dev` The only problem is that it is a .dev domain not  a .com domain?
-

It says subdomains of HackClub.com…….\



Thank you