### PR TITLE
Fiscal sponsorship page: update sign in link

### DIFF
--- a/pages/fiscal-sponsorship/index.js
+++ b/pages/fiscal-sponsorship/index.js
@@ -248,7 +248,7 @@ export default function Page() {
             </Link>
             <Button
               as="a"
-              href="https://hcb.hackclub.com/users/auth"
+              href="https://hcb.hackclub.com"
               variant="outline"
               sx={{ color: 'white' }}
             >


### PR DESCRIPTION
hcb.hackclub.com/users/auth forces an auth page for already signed-in users, which is probably not intended