### PR TITLE
Add HCB email to footers of HCB pages

### DIFF
--- a/pages/fiscal-sponsorship/about.js
+++ b/pages/fiscal-sponsorship/about.js
@@ -487,7 +487,12 @@ export default function FiscalSponsorship() {
           }
         }}
       />
-      <Footer dark phoneNumber="+1 (844) 237 2290" phoneNumberUri="+1-844-237-2290"/>
+      <Footer
+        dark
+        phoneNumber="+1 (844) 237 2290"
+        phoneNumberUri="+1-844-237-2290"
+        email="hcb@hackclub.com"
+      />
     </Box>
   )
 }

--- a/pages/fiscal-sponsorship/climate/index.js
+++ b/pages/fiscal-sponsorship/climate/index.js
@@ -1214,7 +1214,13 @@ export default function ClimatePage({ rawOrganizations, pageRegion }) {
           </Box>
         </Box>
       </Box>
-      <Footer light key="footer" phoneNumber="+1 (844) 237 2290" phoneNumberUri="+1-844-237-2290"/>
+      <Footer
+        light
+        key="footer"
+        phoneNumber="+1 (844) 237 2290"
+        phoneNumberUri="+1-844-237-2290"
+        email="hcb@hackclub.com"
+      />
     </div>
   )
 }

--- a/pages/fiscal-sponsorship/first.js
+++ b/pages/fiscal-sponsorship/first.js
@@ -186,7 +186,13 @@ export default function First({ stats }) {
           <Start stats={stats} />
         </Box>
       </Box>
-      <Footer dark key="footer" phoneNumber="+1 (844) 237 2290" phoneNumberUri="+1-844-237-2290" />
+      <Footer
+        dark
+        key="footer"
+        phoneNumber="+1 (844) 237 2290"
+        phoneNumberUri="+1-844-237-2290"
+        email="hcb@hackclub.com"
+      />
     </>
   )
 }

--- a/pages/fiscal-sponsorship/index.js
+++ b/pages/fiscal-sponsorship/index.js
@@ -581,7 +581,11 @@ export default function Page() {
           </Text>
         </Flex>
       </Box>
-      <Footer phoneNumber="+1 (844) 237 2290" phoneNumberUri="+1-844-237-2290"/>
+      <Footer
+        phoneNumber="+1 (844) 237 2290"
+        phoneNumberUri="+1-844-237-2290"
+        email="hcb@hackclub.com"
+      />
     </>
   )
 }


### PR DESCRIPTION
This was originally added in https://github.com/hackclub/site/pull/1066, but appears to have been accidentally reverted in the HCB landing page redesign