### PR TITLE
Fix GitHub build

### DIFF
--- a/pages/api/github.js
+++ b/pages/api/github.js
@@ -19,7 +19,7 @@ const getMessage = (type, payload, repo) => {
 const getUrl = (type, payload, repo) => {
   switch (type) {
     case 'PushEvent':
-      return payload.commits?.[0].url
+      return payload.commits?.[0]?.url
         ? normalizeGitHubCommitUrl(payload.commits[0].url)
         : 'https://github.com/hackclub'
     case 'PullRequestEvent':


### PR DESCRIPTION
The site was failing to build because one of the latest commits didn't have a URL property and the GitHub code assumed it did. This PR ads optional chaining to prevent that & fix the builds.