### PR TITLE
[The Bin] Remove extra `<` in prelaunch site link

### DIFF
--- a/public/bin/index.html
+++ b/public/bin/index.html
@@ -239,7 +239,7 @@
                         source</a>.
                 </p>
                 <p>
-                    <a href="https://hackclub.com/bin/prelaunch">< Prelaunch site</a>
+                    <a href="https://hackclub.com/bin/prelaunch">Prelaunch site</a>
                     Thank you:
                     <a href="https://awdev.codes" target="_blank">Aaron Wong</a>,
                     <a href="https://github.com/kvnyng" target="_blank">Kevin Yang</a>,


### PR DESCRIPTION
### Before
![image](https://github.com/hackclub/site/assets/20099646/7a7b2b2f-4023-4587-aa68-94e413d6d11f)

###  After
![image](https://github.com/hackclub/site/assets/20099646/bbbd832f-f93d-432e-aeab-6162f1bec972)
