### PR TITLE
Add more padding / space to the "Get your ⚡️ hours" section

### DIFF
--- a/public/arcade/style.css
+++ b/public/arcade/style.css
@@ -410,3 +410,16 @@ a:hover {
     width: calc(100% - 150px);
   }
 }
+
+.section.footer > p {
+    padding: 0px 24px;
+}
+
+.section.footer {
+    padding-bottom: 16px;
+}
+
+.footer > .heading-card {
+    margin-bottom: 1em;
+    padding-top: 3em;
+}


### PR DESCRIPTION
Before:

<img width="1266" alt="Screenshot 2024-06-01 at 7 14 55 PM" src="https://github.com/hackclub/site/assets/39828164/2f317b15-8747-4326-a144-97337d2be4e3">

After: 

<img width="1128" alt="Screenshot 2024-06-01 at 7 14 41 PM" src="https://github.com/hackclub/site/assets/39828164/8c4ba0a4-3309-41ff-b63a-3b4e91617bed">
