### PR TITLE
Fix item name not displaying in modal for Arcade

### DIFF
--- a/pages/arcade/index.js
+++ b/pages/arcade/index.js
@@ -1873,6 +1873,7 @@ export async function getStaticProps() {
       'Image URL': record['Image URL'] || null,
       'Name': record['Name'] || null,
       'Small Name': record['Small Name'] || null,
+      'Full Name': record['Full Name'] || null,
       'Cost Hours': record['Cost Hours'] || null,
       'Description': record['Description'] || null,
       'Fulfillment Description': record['Fulfillment Description'] || null,


### PR DESCRIPTION
Currently, the name isn't displayed in the modal with item info as shown below. This should now fixed.
<img width="421" alt="image" src="https://github.com/hackclub/site/assets/83948303/e5103fa9-e9e3-4b7e-bc01-ff34c5735ea6">
