### PR TITLE
hide packages icon for info modal

### DIFF
--- a/components/arcade/prizes.js
+++ b/components/arcade/prizes.js
@@ -122,6 +122,7 @@ const Prizes = ({
       >
         {cost} {link ? '🎟️' : cost == 1 ? 'ticket' : 'tickets'}
       </Text>
+{/*
       <Text
         variant="headline"
         sx={{
@@ -139,6 +140,7 @@ const Prizes = ({
       >
         📦
       </Text>
+      */}
       <dialog
         id={`${text}-info`}
         sx={{


### PR DESCRIPTION
cc @maxwofford 

Due to how I had the data in local dev, the modals are just showing empty. This is to hide the button until I get chance to fix it (likely tomorrow)