### PR TITLE
Fixed the presence of a horizontal scrollbar on the shop page

### DIFF
--- a/pages/arcade/[userAirtableID]/shop.js
+++ b/pages/arcade/[userAirtableID]/shop.js
@@ -1,8 +1,8 @@
-import ShopComponent from '../../../components/arcade/shop-component'
-import { getArcadeUser } from '../../api/arcade/[userAirtableID]'
-import { shopParts } from '../../api/arcade/shop'
+import ShopComponent from "../../../components/arcade/shop-component"
+import { getArcadeUser } from "../../api/arcade/[userAirtableID]"
+import { shopParts } from "../../api/arcade/shop"
 import { Image, Link, Text } from 'theme-ui'
-import { Balancer } from 'react-wrap-balancer'
+import { Balancer } from "react-wrap-balancer"
 import Meta from '@hackclub/meta'
 import Head from 'next/head'
 
@@ -25,11 +25,8 @@ body {
 
 `
 
-export default function Shop({
-  availableItems,
-  userAirtableID = null,
-  hoursBalance = 0
-}) {
+export default function Shop({ availableItems, userAirtableID = null, hoursBalance = 0 }) {
+  
   return (
     <>
       <Meta
@@ -61,17 +58,8 @@ export default function Shop({
           Welcome to the shop
         </h1>
       </Balancer>
-      <Text
-        sx={{ display: 'block', textAlign: 'center', color: '#35290F' }}
-        className="gaegu"
-        variant="subtitle"
-      >
-        Your current balance is {Math.floor(hoursBalance)} 🎟️
-      </Text>
-      <ShopComponent
-        availableItems={availableItems}
-        userAirtableID={userAirtableID}
-      />
+      <Text sx={{ display: 'block', textAlign: 'center', color: '#35290F' }} className='gaegu' variant='subtitle' >Your current balance is {Math.floor(hoursBalance)} 🎟️</Text>
+      <ShopComponent availableItems={availableItems} userAirtableID={userAirtableID} />
     </>
   )
 }
@@ -83,30 +71,28 @@ export async function getStaticPaths() {
   }
 }
 
-export async function getStaticProps({ params }) {
+export async function getStaticProps({params}) {
   const { userAirtableID } = params
 
   const props = { userAirtableID }
 
   await Promise.all([
     shopParts().then(items => {
-      const availableItems = items
-        .filter(item => item['Enabled'])
-        .map(item => ({
-          Name: item['Name'] || null,
-          Description: item['Description'] || null,
-          'Cost Hours': item['Cost Hours'] || 0,
-          id: item.id,
-          'Image URL': item['Image URL'] || null,
-          'Max Order Quantity': item['Max Order Quantity'] || 1
-        }))
+      const availableItems = items.filter(item => item['Enabled']).map(item => ({
+        'Name': item['Name'] || null,
+        'Description': item['Description'] || null,
+        'Cost Hours': item['Cost Hours'] || 0,
+        id: item.id,
+        'Image URL': item['Image URL'] || null,
+        'Max Order Quantity': item['Max Order Quantity'] || 1
+      }))
       props.availableItems = availableItems
     }),
     getArcadeUser(userAirtableID).then(user => {
-      const hoursBalance = user.fields['Balance (Hours)'] || 0
+      const hoursBalance = user.fields["Balance (Hours)"] || 0
       props.hoursBalance = hoursBalance
     })
   ])
-
+  
   return { props }
 }

--- a/pages/arcade/[userAirtableID]/shop.js
+++ b/pages/arcade/[userAirtableID]/shop.js
@@ -1,8 +1,8 @@
-import ShopComponent from "../../../components/arcade/shop-component"
-import { getArcadeUser } from "../../api/arcade/[userAirtableID]"
-import { shopParts } from "../../api/arcade/shop"
+import ShopComponent from '../../../components/arcade/shop-component'
+import { getArcadeUser } from '../../api/arcade/[userAirtableID]'
+import { shopParts } from '../../api/arcade/shop'
 import { Image, Link, Text } from 'theme-ui'
-import { Balancer } from "react-wrap-balancer"
+import { Balancer } from 'react-wrap-balancer'
 import Meta from '@hackclub/meta'
 import Head from 'next/head'
 
@@ -25,34 +25,53 @@ body {
 
 `
 
-export default function Shop({ availableItems, userAirtableID = null, hoursBalance = 0 }) {
-
+export default function Shop({
+  availableItems,
+  userAirtableID = null,
+  hoursBalance = 0
+}) {
   return (
     <>
-    <Meta
+      <Meta
         as={Head}
         title="Arcade Shop"
         description="Redeem prizes at your own Arcade Shop."
         image="https://cloud-luaw423i2-hack-club-bot.vercel.app/0frame_33__1_.png"
       />
-    <Balancer>
-      <h1
-        sx={{
-          textAlign: 'center',
-          fontSize: 5,
-          color: '#FF8C37',
-          my: 0,
-          pt: 5,
-          display:'block',
-          width: '100vw'
-        }}
-        className="slackey"
-      >
-        Welcome to the shop
-      </h1>
+      <style>
+        {`
+        ._title-container {
+          width: 100%;
+        }
+        `}
+      </style>
+      <Balancer className="_title-container">
+        <h1
+          sx={{
+            textAlign: 'center',
+            fontSize: 5,
+            color: '#FF8C37',
+            my: 0,
+            pt: 5,
+            display: 'block',
+            width: '100%'
+          }}
+          className="slackey"
+        >
+          Welcome to the shop
+        </h1>
       </Balancer>
-      <Text sx={{ display: 'block', textAlign: 'center', color: '#35290F' }} className='gaegu' variant='subtitle' >Your current balance is {Math.floor(hoursBalance)} 🎟️</Text>
-      <ShopComponent availableItems={availableItems} userAirtableID={userAirtableID} />
+      <Text
+        sx={{ display: 'block', textAlign: 'center', color: '#35290F' }}
+        className="gaegu"
+        variant="subtitle"
+      >
+        Your current balance is {Math.floor(hoursBalance)} 🎟️
+      </Text>
+      <ShopComponent
+        availableItems={availableItems}
+        userAirtableID={userAirtableID}
+      />
     </>
   )
 }
@@ -64,28 +83,30 @@ export async function getStaticPaths() {
   }
 }
 
-export async function getStaticProps({params}) {
+export async function getStaticProps({ params }) {
   const { userAirtableID } = params
 
   const props = { userAirtableID }
 
   await Promise.all([
     shopParts().then(items => {
-      const availableItems = items.filter(item => item['Enabled']).map(item => ({
-        'Name': item['Name'] || null,
-        'Description': item['Description'] || null,
-        'Cost Hours': item['Cost Hours'] || 0,
-        id: item.id,
-        'Image URL': item['Image URL'] || null,
-        'Max Order Quantity': item['Max Order Quantity'] || 1
-      }))
+      const availableItems = items
+        .filter(item => item['Enabled'])
+        .map(item => ({
+          Name: item['Name'] || null,
+          Description: item['Description'] || null,
+          'Cost Hours': item['Cost Hours'] || 0,
+          id: item.id,
+          'Image URL': item['Image URL'] || null,
+          'Max Order Quantity': item['Max Order Quantity'] || 1
+        }))
       props.availableItems = availableItems
     }),
     getArcadeUser(userAirtableID).then(user => {
-      const hoursBalance = user.fields["Balance (Hours)"] || 0
+      const hoursBalance = user.fields['Balance (Hours)'] || 0
       props.hoursBalance = hoursBalance
     })
   ])
-  
+
   return { props }
 }

--- a/pages/onboard/index.js
+++ b/pages/onboard/index.js
@@ -237,9 +237,9 @@ const ShipPage = () => {
                 <Balancer ratio={0.3}>
                   Circuit boards are{' '}
                   <Sparkles>
-                    <Text sx={{ fontWeight: 400 }}>magical</Text>
-                  </Sparkles>
-                  . You design one, we'll print it!
+                    <Text sx={{ fontWeight: 400 }}>magical{'.'}</Text>
+                  </Sparkles>{' '}
+                  You design one, we'll print it!
                 </Balancer>
               </Heading>
 


### PR DESCRIPTION
When opening the arcade shop page (ex: https://hackclub.com/arcade/[ID HERE]/shop/), a horizontal scrollbar appears on the bottom (see picture):
![image](https://github.com/hackclub/site/assets/65409906/6d0c5bb9-f864-44a2-96fa-cfebcbd8e502)

This is the case because the tag which contains "Welcome to the shop" has a width of `100 view-width`, instead of container percentage; as there is a vertical scrollbar, 100% of the view-width would go over that vertical scrollbar, therefore overflowing from the page.

Furthermore, even fixing the issue with the h1's width didn't seem to work, as it's container's display is `inline-block`, therefore not correctly sizing itself to the page's width

I couldn't find a way to set `width: 100%` directly on the title's container element, which is a `Balancer`; It seems that we can't add style properties on it as they are overwritten by the wrap balancer's code (see https://github.com/shuding/react-wrap-balancer/blob/704dabd9f9bbdfdb75e4a9b0ecec9b5fa91e559c/src/index.tsx#L259)

The solution I have implemented (adding a classname) is pretty hacky, but it should work.

If anyone has input on how I can make it more functional/integrated with React in a cleaner way, feel free to comment!

PS: It's my first time actually writting a bit of React (I had only read some before), so maybe there's an obvious solution I'm missing here