### PR TITLE
Fix arcade shop link colors

### DIFF
--- a/components/arcade/shop-component.js
+++ b/components/arcade/shop-component.js
@@ -18,7 +18,11 @@ const styled = `
 body {
   background-color: #FAEFD6;
 }
-`;
+
+a {
+  color: inherit;
+}
+`
 
 export default function ShopComponent({
   availableItems,

--- a/components/arcade/shop-component.js
+++ b/components/arcade/shop-component.js
@@ -22,7 +22,7 @@ body {
 a {
   color: inherit;
 }
-`
+`;
 
 export default function ShopComponent({
   availableItems,


### PR DESCRIPTION
Resolves #1246

This adds the missing styles to links in the arcade shop items, following the format on the [main page](https://github.com/hackclub/site/blob/a35c5d215ef0012346c7e5aaadf464e55ecef3ac/pages/arcade/index.js#L173-L175).

It no longer uses the browser default (blue)
![image](https://github.com/hackclub/site/assets/66446458/5e1b2bfb-41da-4754-91bd-87845a5cc6c3)

P.S. I do not have access to creds, so it was tested with hard-coded data.