### PR TITLE
Add stock UI to signed-out Arcade Shop

### DIFF
--- a/pages/arcade/shop.js
+++ b/pages/arcade/shop.js
@@ -78,7 +78,8 @@ export async function getStaticProps() {
         'Cost Hours': item['Cost Hours'] || 0,
         id: item.id,
         'Image URL': item['Image URL'] || null,
-        'Max Order Quantity': item['Max Order Quantity'] || 1
+        'Max Order Quantity': item['Max Order Quantity'] || 1,
+        Stock: item['Stock'] || null
       }))
       props.availableItems = availableItems
     }),


### PR DESCRIPTION
Looks like I didn't merge the stock UI to the signed-out Arcade Shop.

Sorry!

Anyways, this PR adds that back.