### PR TITLE
Small change, updated bio cards in team

### DIFF
--- a/components/bio.js
+++ b/components/bio.js
@@ -17,7 +17,7 @@ export default function Bio({ popup = true, spanTwo = false, ...props }) {
           alignItems: popup ? 'center' : 'flex-start',
           transition: 'transform 0.125s ease-in-out',
           '&:hover':
-            (text && popup) || href ? { transform: 'scale(1.025)' } : {},
+            { transform: 'scale(1.025)' },
           cursor: (text && popup) || href ? 'pointer' : null,
           textDecoration: 'none',
           maxWidth: '600px',


### PR DESCRIPTION
This is a very small change but the cards in https://hackclub.com/team/ which didn't have the bio description seemed off as they didn't scale when hovered over. Now it's more or less uniform and can still be differentiated by the cursor (it's a pointer over the ones you can click and default over the ones which don't have a description).

Other than that, just wanted to suggest including descriptions for them as well so that everyone can get to know everyone better.