### PR TITLE
Slightly updated the arcade alert

### DIFF
--- a/components/announcement.js
+++ b/components/announcement.js
@@ -1,7 +1,7 @@
-import { Card, Text, Box } from 'theme-ui'
 import { keyframes } from '@emotion/react'
-import Icon from './icon'
 import Image from 'next/image'
+import { Box, Card, Text } from 'theme-ui'
+import Icon from './icon'
 
 const unfold = keyframes({
   from: { transform: 'scaleY(0)' },
@@ -17,6 +17,7 @@ const Announcement = ({
   imgAlt,
   color = 'accent',
   sx = {},
+  width,
   ...props
 }) => (
   <Card
@@ -26,7 +27,7 @@ const Announcement = ({
       variant: 'cards.translucent',
       mx: 'auto',
       maxWidth: 'narrow',
-      width: '100%',
+      width: width ? width : '100%',
       textAlign: 'left',
       textDecoration: 'none',
       lineHeight: 'caption',

--- a/components/bio.js
+++ b/components/bio.js
@@ -1,6 +1,6 @@
-import { Box, Flex, Text, Avatar, Card } from 'theme-ui'
 import Icon from '@hackclub/icons'
 import { useState } from 'react'
+import { Avatar, Box, Card, Flex, Text } from 'theme-ui'
 
 export default function Bio({ popup = true, spanTwo = false, ...props }) {
   let { img, name, teamRole, pronouns, text, subrole, email, href, video } =
@@ -17,7 +17,7 @@ export default function Bio({ popup = true, spanTwo = false, ...props }) {
           alignItems: popup ? 'center' : 'flex-start',
           transition: 'transform 0.125s ease-in-out',
           '&:hover':
-            (text && popup) || href ? { transform: 'scale(1.025)' } : {},
+            { transform: 'scale(1.025)' },
           cursor: (text && popup) || href ? 'pointer' : null,
           textDecoration: 'none',
           maxWidth: '600px',

--- a/components/bio.js
+++ b/components/bio.js
@@ -17,7 +17,7 @@ export default function Bio({ popup = true, spanTwo = false, ...props }) {
           alignItems: popup ? 'center' : 'flex-start',
           transition: 'transform 0.125s ease-in-out',
           '&:hover':
-            { transform: 'scale(1.025)' },
+            (text && popup) || href ? { transform: 'scale(1.025)' } : {},
           cursor: (text && popup) || href ? 'pointer' : null,
           textDecoration: 'none',
           maxWidth: '600px',

--- a/pages/index.js
+++ b/pages/index.js
@@ -204,6 +204,7 @@ function Page({
             gradient="linear-gradient(rgba(0,0,0,0.4), rgba(0,0,0,0.45))"
           />
 	  <Announcement
+            width="90vw"
             copy="Build in public this summer!"
             caption="Get domains, breadboards & multimeters, and drawing tablets."
             href="/arcade/"


### PR DESCRIPTION
I know this is a very small edit but it seemed often on phone as it took up the entire width. 

Before:
![image](https://github.com/hackclub/site/assets/49610482/f803f06b-6121-4780-a563-9dc0ca57c15a)


After:
![image](https://github.com/hackclub/site/assets/49610482/4f9692ba-e88e-4e35-8e3c-3634891db17f)

It doesn't change anything on larger screens as the max-width is still fixed