### PR TITLE
Consistent ticket representation when signed out or in

### DIFF
--- a/components/arcade/prizes.js
+++ b/components/arcade/prizes.js
@@ -161,7 +161,7 @@ const Prizes = ({
         variant="headline"
         className="gaegu"
       >
-        {cost} {link ? '🎟️' : cost == 1 ? 'ticket' : 'tickets'}
+        {cost} 🎟️
       </Text>
       <Text
         variant="headline"


### PR DESCRIPTION
When viewing the signed out shop, text "tickets" is used instead of the emoji on the signed in page. Now they both use the emoji.
Also should prevent cases like this:
![image](https://github.com/hackclub/site/assets/83948303/07392d28-64d3-4e7b-8aa2-cfab97fffef5)
