### PR TITLE
Fix 0 on out of stock items

### DIFF
--- a/components/arcade/prizes.js
+++ b/components/arcade/prizes.js
@@ -86,7 +86,7 @@ const Prizes = ({
               alt={text}
             />
           </Flex>
-          {stock && stock != null && stock > 0 && stock <= 100 && (
+          {inStock && stock != null && stock > 0 && stock <= 100 && (
             <Text
               sx={{
                 background: '#CC6CE7',


### PR DESCRIPTION
This should fix the 0 shown on out of stock items which is shown as it's trying to display the stock count
![image](https://github.com/user-attachments/assets/a1592948-8e92-4791-8465-3fb24c2de79b)
