### PR TITLE
removed order up to feature

### DIFF
--- a/components/arcade/prizes.js
+++ b/components/arcade/prizes.js
@@ -146,10 +146,7 @@ const Prizes = ({
                 variant="caption"
                 sx={{ color: '#FFEEC6', mt: 0, mb: 2 }}
               >
-                <em>
-                  You can order up to{' '}
-                  {Math.min(quantity, Math.floor(hoursBalance / cost))} of these
-                </em>
+                <em></em>
               </Text>
             </Balancer>
           )}
@@ -166,10 +163,7 @@ const Prizes = ({
                     : null
                 ) ? (
                   <Quantity
-                    numOptions={Math.min(
-                      quantity,
-                      Math.floor(hoursBalance / cost)
-                    )}
+                    numOptions={quantity}
                     label={text}
                     onQuantityChange={onQuantityChange}
                     index={index}
@@ -178,7 +172,6 @@ const Prizes = ({
               }
               {
                 // only show the buy button if you have enough hours to buy at least 1 of the item
-                //                 (hoursBalance ? hoursBalance / cost < 1 ? stock != 0 ? null )  null : (
                 (
                   hoursBalance
                     ? hoursBalance / cost >= 1
@@ -383,10 +376,7 @@ const Prizes = ({
                           : null
                       ) ? (
                         <Quantity
-                          numOptions={Math.min(
-                            quantity,
-                            Math.floor(hoursBalance / cost)
-                          )}
+                          numOptions={quantity}
                           label={text}
                           onQuantityChange={onQuantityChange}
                           index={index}
@@ -432,11 +422,7 @@ const Prizes = ({
                     width: '100%'
                   }}
                 >
-                  <em>
-                    You can order up to{' '}
-                    {Math.min(quantity, Math.floor(hoursBalance / cost))} of
-                    these
-                  </em>
+                  <em></em>
                 </Text>
               </div>
             </div>


### PR DESCRIPTION
## Description

This pull request removes the "you can order up to" feature from the `Prizes` component.

## Changes Made

- Removed the "you can order up to" feature from the `Prizes` component.

#1252 fixed


## How to Test

1. Checkout to this branch: `git checkout remove-order-up-feature`
2. Run the project: `npm start` or `yarn start`
3. Navigate to the component where `Prizes` is used and verify that the "you can order up to" feature has been removed.

## Checklist

- [x] Code changes have been tested manually
- [ ] Documentation has been updated (if applicable)
- [ ] Unit tests have been added/updated (if applicable)
- [x] All checks (e.g., CI/CD) pass successfully

## Related Issues

None.

## Additional Notes

None.
