### PR TITLE
fix: typo in object property name

### DIFF
--- a/pages/arcade/showcase/project/[projectID]/index.js
+++ b/pages/arcade/showcase/project/[projectID]/index.js
@@ -85,7 +85,7 @@ const ProjectShowPage = ({ projectID }) => {
               key={project.id}
               id={project.id}
               title={project.title}
-              desc={project.description}
+              description={project.description}
               slack={project.slackLink}
               codeLink={project.codeLink}
               playLink={project.playLink}

--- a/pages/arcade/showcase/project/[projectID]/index.js
+++ b/pages/arcade/showcase/project/[projectID]/index.js
@@ -85,7 +85,7 @@ const ProjectShowPage = ({ projectID }) => {
               key={project.id}
               id={project.id}
               title={project.title}
-              desc={project.desc}
+              desc={project.description}
               slack={project.slackLink}
               codeLink={project.codeLink}
               playLink={project.playLink}


### PR DESCRIPTION
Due to the typo the description didn't show up in project page
```diff
- desc: project.desc
+ description: project.description
```