### PR TITLE
feat: round showcase container card images

### DIFF
--- a/components/arcade/showcase/cohort-card.js
+++ b/components/arcade/showcase/cohort-card.js
@@ -120,11 +120,13 @@ const CohortCard = ({
           target="_blank"
           rel="noopener noreferrer"
         >
-          <img
-            src={firstImage}
-            alt="Project Image"
-            className={styles.card_img}
-          />
+          <div className={styles.card_img_container}>
+            <img
+              src={firstImage}
+              alt="Project Image"
+              className={styles.card_img}
+            />
+          </div>
           <h1 sx={{ color: textColor }} className={styles.card_title}>
             {title}
           </h1>

--- a/components/arcade/showcase/cohort-card.module.css
+++ b/components/arcade/showcase/cohort-card.module.css
@@ -12,15 +12,21 @@
     justify-content: flex-start;
     position: relative;
     padding: 10px;
+    border-radius: 10px;
 }
 
 .card_img {
-    width: 100%;
     max-width: 200px;
     height: auto;
     max-height: 100%;
-    object-fit: contain;
     aspect-ratio: 1 / 1;
+    border-radius: 5px;
+}
+
+.card_img_container {
+    height: 200px;
+    align-items: center;
+    display: grid;
 }
 
 .card_title {

--- a/components/arcade/showcase/project-view.js
+++ b/components/arcade/showcase/project-view.js
@@ -106,7 +106,8 @@ const ProjectView = ({
         position: 'relative',
         backgroundColor: color,
         color: textColor,
-        minHeight: '100vh'
+        minHeight: '100vh',
+        height: '100%'
       }}
     >
       <style>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/378c490b-adff-4760-8ce8-dcd3d66490d1)
fixed the weird border at the bottom of the edit page

![image](https://github.com/user-attachments/assets/1facf2cd-ae98-474a-8187-826af04a9f67)
added a border to the showcase cards