### PR TITLE
(Showcase) Fallback to playing project video from URL

### DIFF
--- a/components/arcade/showcase/youtube-renderer.js
+++ b/components/arcade/showcase/youtube-renderer.js
@@ -2,17 +2,28 @@ import LiteYouTubeEmbed from 'react-lite-youtube-embed';
 import 'react-lite-youtube-embed/dist/LiteYouTubeEmbed.css'
 
 const YoutubeRenderer = ({ youtubeLink }) => {
-  if (!youtubeLink) return null
-  const youtubeID = youtubeLink.split('v=')[1]
-  if (!youtubeID) return <p>Invalid YouTube link: "{youtubeLink}"</p>
+  if (!youtubeLink) return null;
 
+  const isYouTubeLink = youtubeLink.includes('youtube.com') || youtubeLink.includes('youtu.be');
+  if (isYouTubeLink) {
+    const youtubeID = youtubeLink.split('v=')[1];
+    if (!youtubeID) return <p>Invalid YouTube link: "{youtubeLink}"</p>;
+
+    return (
+      <LiteYouTubeEmbed
+        id={youtubeID}
+        adNetwork={false}
+        noCookie={true}
+      />
+    );
+  }
   return (
-    <LiteYouTubeEmbed
-      id={youtubeID}
-      adNetwork={false}
-      noCookie={true}
-    />
-  )
-}
+    <video controls>
+      <source src={youtubeLink} type="video/mp4" />
+      Your browser does not support the video tag.
+    </video>
+  );
+};
+
 
 export default YoutubeRenderer


### PR DESCRIPTION
Currently, only YouTube videos are supported for the project demo. 
This PR makes `YoutubeRenderer` fallback to playing from a URL if, for example, a link from `#cdn` or a raw GItHub link is set. 

I wasn't sure how to test it as projects are pulled from Airtable, however.