### PR TITLE
Fixed inRunning showing true for all users

### DIFF
--- a/pages/api/arcade/showcase/projects/my.js
+++ b/pages/api/arcade/showcase/projects/my.js
@@ -21,7 +21,8 @@ const getProjects = async function (authToken) {
       'Play Link',
       'ScreenshotLink',
       'color',
-      'textColor'
+      'textColor',
+      'Lost Cohorts'
     ]
   })
 
@@ -57,6 +58,7 @@ export default async function handler(req, res) {
       user: user.fields['Name'],
       color: p.fields['color'] || '',
       textColor: p.fields['textColor'] || '',
+      inRunning: false,
     }
 
     if (hasVoted) {

--- a/pages/api/arcade/showcase/projects/my.js
+++ b/pages/api/arcade/showcase/projects/my.js
@@ -57,8 +57,7 @@ export default async function handler(req, res) {
       imageLink: p.fields['ScreenshotLink'] || '',
       user: user.fields['Name'],
       color: p.fields['color'] || '',
-      textColor: p.fields['textColor'] || '',
-      inRunning: false,
+      textColor: p.fields['textColor'] || ''
     }
 
     if (hasVoted) {

--- a/pages/api/arcade/showcase/projects/my.js
+++ b/pages/api/arcade/showcase/projects/my.js
@@ -22,7 +22,7 @@ const getProjects = async function (authToken) {
       'ScreenshotLink',
       'color',
       'textColor',
-      'Lost Cohorts'
+      'Lost Cohorts',
     ]
   })
 
@@ -57,7 +57,7 @@ export default async function handler(req, res) {
       imageLink: p.fields['ScreenshotLink'] || '',
       user: user.fields['Name'],
       color: p.fields['color'] || '',
-      textColor: p.fields['textColor'] || ''
+      textColor: p.fields['textColor'] || '',
     }
 
     if (hasVoted) {


### PR DESCRIPTION
The `airtable.read` function in /api/arcade/showcase/projects/my.js does not request the `Lost Cohorts` field, so it returns the value as `null | undefined` in the if condition at line 63. Since the `Boolean` conversion of a null or undefined value is inherently `false`, adding the NOT [!] operator would invert it, showing all projects as in the running.