### PR TITLE
Disable arcade joining

### DIFF
--- a/components/arcade/join.js
+++ b/components/arcade/join.js
@@ -108,7 +108,7 @@ const Join = ({ fold, last, showForm, setForm, formSent, setFormSent }) => {
           )
         ) : (
           <form
-            onSubmit={handleFormSubmit}
+            // onSubmit={handleFormSubmit}
             sx={{
               height: '100%'
             }}
@@ -210,10 +210,11 @@ const Join = ({ fold, last, showForm, setForm, formSent, setFormSent }) => {
                   // cursor: highschool ? 'pointer': 'not-allowed',
                   transitionDuration: '0.3s',
                   '&:hover': {
-                    transform: 'scale(1.05)'
+                    // transform: 'scale(1.05)',
                   }
                 }}
                 className="slackey"
+                disabled={true}
               >
                 Join ARCADE
               </button>
@@ -232,8 +233,8 @@ const Join = ({ fold, last, showForm, setForm, formSent, setFormSent }) => {
             justifyContent: 'center',
             alignItems: 'center',
             textDecoration: 'none',
-            backgroundColor: '#FF5C00',
-            cursor: 'pointer',
+            backgroundColor: '#818FA2',
+            cursor: 'not-allowed',
             color: '#FAEFD6',
             width: 'fit-content',
             paddingX: ['8px', '10px', '15px'],
@@ -246,7 +247,7 @@ const Join = ({ fold, last, showForm, setForm, formSent, setFormSent }) => {
             zIndex: 2,
             transitionDuration: '0.3s',
             '&:hover': {
-              transform: 'scale(1.05)'
+              // transform: 'scale(1.05)'
             }
           }}
         >

--- a/pages/arcade/index.js
+++ b/pages/arcade/index.js
@@ -1085,7 +1085,13 @@ const Arcade = ({ stickers = [], carousel = [], highlightedItems = [] }) => {
                     display: 'block'
                   }}
                 >
-                  For high schoolers (or younger).
+                  The Arcade closed September 1st, but you can still join the <a
+                      href="https://hackclub.com/slack"
+                      target="_blank"
+                      sx={{ color: 'inherit' }}
+                    >
+                      Hack Club Slack
+                    </a>!
                 </Text>
               )}
             </Fade>


### PR DESCRIPTION
New people are still joining through the Arcade flow, this will disable the flow on the frontend and point them to /slack