### PR TITLE
Fix bug in shop page

### DIFF
--- a/components/arcade/quantity.js
+++ b/components/arcade/quantity.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
 /** @jsxImportSource theme-ui */
 const styled = `
-@import url('https://fonts.googleapis.com/css2?family=Slackey&family=Emblema+One&family=Gaegu&display=swap');
+@import url(https://fonts.googleapis.com/css2?family=Slackey&family=Emblema+One&family=Gaegu&display=swap);
 
 .slackey {
   font-family: "Slackey", sans-serif;

--- a/components/arcade/shop-component.js
+++ b/components/arcade/shop-component.js
@@ -5,7 +5,7 @@ import Prizes from './prizes';
 /** @jsxImportSource theme-ui */
 
 const styled = `
-@import url('https://fonts.googleapis.com/css2?family=Slackey&family=Emblema+One&family=Gaegu&display=swap');
+@import url(https://fonts.googleapis.com/css2?family=Slackey&family=Emblema+One&family=Gaegu&display=swap);
 
 .slackey {
   font-family: "Slackey", sans-serif;

--- a/pages/arcade/[userAirtableID]/shop.js
+++ b/pages/arcade/[userAirtableID]/shop.js
@@ -10,7 +10,7 @@ import Flag from '../../../components/flag'
 /** @jsxImportSource theme-ui */
 
 const styled = `
-@import url('https://fonts.googleapis.com/css2?family=Slackey&family=Emblema+One&family=Gaegu&display=swap');
+@import url(https://fonts.googleapis.com/css2?family=Slackey&family=Emblema+One&family=Gaegu&display=swap);
 
 .slackey {
   font-family: "Slackey", sans-serif;

--- a/pages/arcade/index.js
+++ b/pages/arcade/index.js
@@ -22,7 +22,7 @@ import { shopParts } from '../api/arcade/shop'
 /** @jsxImportSource theme-ui */
 
 const styled = `
-@import url('https://fonts.googleapis.com/css2?family=Slackey&family=Emblema+One&family=Gaegu&display=swap');
+@import url(https://fonts.googleapis.com/css2?family=Slackey&family=Emblema+One&family=Gaegu&display=swap);
 body, html {
   overflow-x: hidden;
   }

--- a/pages/arcade/shop.js
+++ b/pages/arcade/shop.js
@@ -10,7 +10,7 @@ import Flag from '../../components/flag'
 /** @jsxImportSource theme-ui */
 
 const styled = `
-@import url('https://fonts.googleapis.com/css2?family=Slackey&family=Emblema+One&family=Gaegu&display=swap');
+@import url(https://fonts.googleapis.com/css2?family=Slackey&family=Emblema+One&family=Gaegu&display=swap);
 
 .slackey {
   font-family: "Slackey", sans-serif;

--- a/pages/arcade/showcase/my.js
+++ b/pages/arcade/showcase/my.js
@@ -10,7 +10,7 @@ import { DateTime } from 'luxon'
 /** @jsxImportSource theme-ui */
 
 const styled = `
-@import url('https://fonts.googleapis.com/css2?family=Slackey&family=Emblema+One&family=Gaegu&display=swap');
+@import url(https://fonts.googleapis.com/css2?family=Slackey&family=Emblema+One&family=Gaegu&display=swap);
 body, html {
   overflow-x: hidden;
   }

--- a/pages/arcade/showcase/project/[projectID]/index.js
+++ b/pages/arcade/showcase/project/[projectID]/index.js
@@ -4,7 +4,7 @@ import styles from '../../../../../components/arcade/showcase/project-view.modul
 /** @jsxImportSource theme-ui */
 
 const styled = `
-@import url('https://fonts.googleapis.com/css2?family=Slackey&family=Emblema+One&family=Gaegu&display=swap');
+@import url(https://fonts.googleapis.com/css2?family=Slackey&family=Emblema+One&family=Gaegu&display=swap);
 body, html {
   overflow-x: hidden;
   }

--- a/pages/arcade/showcase/vote.js
+++ b/pages/arcade/showcase/vote.js
@@ -20,7 +20,7 @@ function getStyle(style, snapshot) {
 }
 
 const styled = `
-@import url('https://fonts.googleapis.com/css2?family=Slackey&family=Emblema+One&family=Gaegu&display=swap');
+@import url(https://fonts.googleapis.com/css2?family=Slackey&family=Emblema+One&family=Gaegu&display=swap);
 body, html {
   overflow-x: hidden;
   color: #35290F;


### PR DESCRIPTION
In the arcade shop styles the singe quote in url() is escaped to `&#x27;` leading to requesting the fonts from: `https://hackclub.com/arcade/receW2pZGukBzeZdu/shop/&#x27;https://fonts.googleapis.com/css2?family=Slackey&amp;family=Emblema+One&amp;family=Gaegu&amp;display=swap&#x27;` This of course does not exist but until the 404 response arrives the browser can not continue rendering because styles are render-blocking. Also, the style is duplicated in every card and so this makes each item appear one by one.

This PR fixes this by removing the single quote since url() does not need quotes.
On my browser the time to complete loading went from 4 s to 2.6 s (both dev builds with airtable commented out and replaced with static array). Testing on live shop website by just blocking the requests for `https://hackclub.com/arcade/receW2pZGukBzeZdu/shop/&` makes the time to complete loading go from 9.2 s to 5.6 s