### PR TITLE
Fix email service name in footer

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -177,7 +177,7 @@ const Footer = ({
               icon="instagram"
               name="Instagram"
             />
-            <Service href={`mailto:${email}`} icon="email-fill" />
+            <Service href={`mailto:${email}`} icon="email-fill" name="Email" />
           </Grid>
           <Text my={2}>
             <Link href="tel:1-855-625-HACK">1-855-625-HACK</Link>


### PR DESCRIPTION
Name shows on the tooltip when you hover