### PR TITLE
Actually disable arcade join button

### DIFF
--- a/components/arcade/join.js
+++ b/components/arcade/join.js
@@ -224,9 +224,9 @@ const Join = ({ fold, last, showForm, setForm, formSent, setFormSent }) => {
       ) : (
         <Flex
           as="a"
-          onClick={() => {
-            setForm(true)
-          }}
+          // onClick={() => {
+          //   setForm(true)
+          // }}
           target="_blank"
           className="slackey"
           sx={{


### PR DESCRIPTION
Turns out the button was just greyed out, not disabled, whoops. This fixes that