### PR TITLE
Fix icons for Bin and OnBoard in carousel

### DIFF
--- a/lib/carousel.json
+++ b/lib/carousel.json
@@ -23,7 +23,7 @@
     "descriptionColor": "black",
     "title": "The Bin",
     "description": "A free electronics starter kit for high schoolers, shipped to your door.",
-    "img": "https://cloud-hub9gx4my-hack-club-bot.vercel.app/0bin.gif",
+    "img": "https://cloud-19s894dm1-hack-club-bot.vercel.app/08842522a-d52d-40e8-9113-0fea592512d7.gif",
     "link": "https://hackclub.com/bin"
   },
   {
@@ -59,7 +59,7 @@
     "descriptionColor": "white",
     "title": "OnBoard",
     "description": "Join 1k teens designing PCBs, learning hardware, and building electronics",
-    "img": "https://cloud-jrox24mrn.vercel.app/orpheus_leap_micro_final.png",
+    "img": "https://cloud-6skkg6eck-hack-club-bot.vercel.app/0image.png",
     "link": "/onboard"
   },
   {


### PR DESCRIPTION
The icons were just showing "carousel card". I believe it has something to do with the fact that they used #cdn a while ago, and the links are now broken. I reuploaded the images and updated the link.