### PR TITLE
minecraft.js link fixed

### DIFF
--- a/pages/minecraft.js
+++ b/pages/minecraft.js
@@ -80,7 +80,7 @@ const Page = () => (
             <Text as="p">
               Hang out with the tree-punchers of Hack&nbsp;Club playing on the
               official server, mc.hackclub.com.{' '}
-              <Link href="http://mc.hackclub.com:2008" color="#759B40">
+              <Link href="http://mc.hackclub.com" color="#759B40">
                 Check out the map »
               </Link>
             </Text>


### PR DESCRIPTION
I fixed the link on the Minecraft page [https://hackclub.com/minecraft/](https://hackclub.com/minecraft/). Previously it was set to [mc.hackclub.com:2008](mc.hackclub.com:2008). This doesnt work, since it's the bedrock ip, not the server ip. I changed it to [mc.hackclub.com](mc.hackclub.com), since this is what actually works