### PR TITLE
Make /github redirect to HackClub GitHub org

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -202,6 +202,11 @@ const nextConfig = {
         destination: '/philanthropy',
         permanent: false
       },
+      {
+        source: '/github',
+        destination: 'https://github.com/hackclub',
+        permanent: true
+      },
     ]
   },
   async rewrites() {


### PR DESCRIPTION
All emails from HackClub (specifically Zach Latta) contain a link in the email signature to https://hackclub.com/github. At the moment, clicking this link simply sends the recipient to a 404 page, which is rather unhelpful. Therefore I thought it might be a good idea to create a new redirect which would fix this issue. This PR simply does that.