### PR TITLE
Remove broken slack links on Hackathon Grant page that redirect to High Seas

### DIFF
--- a/components/hackathons/grant/apply.js
+++ b/components/hackathons/grant/apply.js
@@ -134,17 +134,7 @@ const Apply = ({ channel }) => {
             duration="Step 1"
             name={
               <>
-                On{' '}
-                <Link
-                  href="https://hackclub.com/slack"
-                  target="_blank"
-                  sx={{
-                    color: 'white'
-                  }}
-                >
-                  Slack
-                </Link>
-                , send your website to{' '}
+                On Slack, send your website to{' '}
                 <Link href={channel} target="_blank">
                   #hackathon-grants
                 </Link>
@@ -181,24 +171,6 @@ const Apply = ({ channel }) => {
       </Grid>
 
       <Slide left>
-        <Link
-          href="/slack/?reason=Application%20for%20the%20high%20school%20hackathon%20grant"
-          target="_blank"
-          sx={{ textDecoration: 'none' }}
-        >
-          <Button
-            as="a"
-            variant="primary"
-            sx={{
-              fontSize: [2, null, 3],
-              display: 'block',
-              mx: 'auto',
-              width: 'fit-content'
-            }}
-          >
-            Join Slack
-          </Button>
-        </Link>
         <Box
           sx={{
             fontSize: ['14px', 1, 1],

--- a/pages/hackathons/grant.js
+++ b/pages/hackathons/grant.js
@@ -316,17 +316,7 @@ const HackathonGrant = () => {
                 >
                   guide on building hackathon websites
                 </Link>{' '}
-                or ask in{' '}
-                <Link
-                  href="/slack"
-                  target="_blank"
-                  sx={{
-                    color: 'muted'
-                  }}
-                >
-                  Slack
-                </Link>{' '}
-                if you need help.
+                or ask in Slack if you need help.
               </Text>
             </Requirement>
             <Requirement


### PR DESCRIPTION
This is confusing for grant applicants who suddenly get redirected from the grant page to a seemingly unrelated program.