### PR TITLE
Fix checkbox on fiscal sponsorship form

### DIFF
--- a/components/fiscal-sponsorship/apply/personal-form.js
+++ b/components/fiscal-sponsorship/apply/personal-form.js
@@ -1,7 +1,8 @@
-import { Input, Flex, Label, Radio, Grid, Select, Checkbox } from 'theme-ui'
+import { Input, Flex, Label, Radio, Grid, Select } from 'theme-ui'
 import Field from './field'
 import { useEffect, useState } from 'react'
 import { useTeenagerLedContext } from './teenager-led-context'
+import Checkbox from './checkbox'
 
 export default function PersonalInfoForm({ requiredFields }) {
   const [selectedContactOption, setSelectedContactOption] = useState('Email')


### PR DESCRIPTION
This fixes the checkbox by using the existing custom component instead of checkbox from theme-ui