### PR TITLE
Removed Clubs Directory

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -117,7 +117,6 @@ const Footer = ({
           <Link href="https://events.hackclub.com/">Community Events</Link>
           <Link href="https://jams.hackclub.com/">Jams</Link>
           <Link href="https://toolbox.hackclub.com/">Toolbox</Link>
-          <Link href="https://directory.hackclub.com/">Clubs Directory</Link>
           <Link href="https://hackclub.com/conduct/">Code of Conduct</Link>
         </Box>
         <Box sx={{ gridColumn: ['span 2', 'span 1'] }}>


### PR DESCRIPTION
Removed Clubs Directory since it been removed from vercel and now redirect back to `https://hackclub.com/`