### PR TITLE
update link to sprig security

### DIFF
--- a/components/security/content.mdx
+++ b/components/security/content.mdx
@@ -14,7 +14,7 @@ something as a thank you.
 
 Some projects may have specific security policies. Please refer to the table below for more information.
 
-| Project | Security Policy                                                                     |
-| ------- | ----------------------------------------------------------------------------------- |
-| HCB     | [hcb.hackclub.com/security](https://hcb.hackclub.com/security)                      |
-| Sprig   | [github.com/hackclub/sprig](https://github.com/hackclub/sprig?tab=security-ov-file) |
+| Project | Security Policy                                                                                                         |
+| ------- | ----------------------------------------------------------------------------------------------------------------------- |
+| HCB     | [hcb.hackclub.com/security](https://hcb.hackclub.com/security)                                                          |
+| Sprig   | [github.com/hackclub/sprig](https://github.com/hackclub/sprig?tab=security-ov-file#reporting-security-issues-%EF%B8%8F) |


### PR DESCRIPTION
Adding this little bit pulls the screen down to the security section as opposed to just switching the tab over. 