### PR TITLE
Update broken url in slack channels page

### DIFF
--- a/components/slack/channels.js
+++ b/components/slack/channels.js
@@ -9,7 +9,7 @@ const withCommas = x => x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
 
 export default function Channels() {
   const { data: millionCount } = useSWR(
-    'https://jia.samuel.hackclub.app/api/currentNumber',
+    'https://drac.firepup650.hackclub.app/api/currentNumber',
     fetcher,
     { refreshInterval: 10_000 }
   )


### PR DESCRIPTION
Update old and offline jia url to point to the current instance of drac, which has been updated to replace jia completely

A newer version of #1479