### PR TITLE
Speed up team page

### DIFF
--- a/pages/api/team.ts
+++ b/pages/api/team.ts
@@ -21,30 +21,6 @@ export async function fetchTeam() {
   const acknowledged: TeamMember[] = []
 
   for (const member of teamMembers as TeamMember[]) {
-    if (process.env.SLACK_API_TOKEN) {
-      const formData = new FormData()
-      formData.append('token', process.env.SLACK_API_TOKEN)
-      formData.append('user', member.slackId)
-
-      const slackData = await fetch(
-        `https://hackclub.slack.com/api/users.profile.get?user=${member.slackId}`,
-        {
-          method: 'POST',
-          headers: {
-            'content-type': 'multipart/form-data',
-            cookie: process.env.SLACK_API_COOKIE || ''
-          },
-          body: formData
-        }
-      ).then(r => r.json())
-
-      if (slackData.ok) {
-        member.pronouns = slackData.profile.pronouns
-      } else {
-        console.warn('Not found:', member.slackId)
-      }
-    }
-
     if (member.acknowledged) {
       acknowledged.push(member)
     } else {


### PR DESCRIPTION
Fixes https://github.com/hackclub/site/issues/1506

The team page currently performs a request to the Slack API for every team member in order to populate their pronouns: https://github.com/hackclub/site/blob/89d64f2d0c8e4aae1d088b29a363176430e065a2/pages/api/team.ts#L24-L46

This adds a considerable amount of latency to the endpoint as we have to perform ~140 requests serially for data that is unlikely to change very often and can be manually updated by the relevant users.

Instead, this PR
- ~Adds a `pronouns` field where relevant based on Slack data~
    We decided not to do this: https://github.com/hackclub/site/pull/1577#issuecomment-3186634218
- Removes the calls to the Slack API