### PR TITLE
Remove redirect to SoM for '/slack/' endpoint

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -71,11 +71,6 @@ const nextConfig = {
       },
       { source: '/slack_invite/', destination: '/slack/', permanent: true },
       {
-        source: '/slack/',
-        destination: 'https://summer.hackclub.com',
-        permanent: false
-      },
-      {
         source: '/jobs/bank-tech-lead/',
         destination: '/jobs/lead-hacker/',
         permanent: true


### PR DESCRIPTION
Removed redirect from '/slack/' to external URL.