### PR TITLE
Re-add Slack CTA button to homepage

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -331,6 +331,17 @@ function Page({
                     Get up to $400 to make Hardware
                   </Text>
                 </Button>
+
+                <Button
+                  variant="ctaLg"
+                  as="a"
+                  href="/slack"
+                  mt={[3, 0, 0]}
+                  mr={3}
+                  sx={{ transformOrigin: 'center left' }}
+                >
+                  Join Slack
+                </Button>
               </Box>
             </Heading>
           </Box>


### PR DESCRIPTION
Quick PR that re-adds the "Join Slack" CTA button (links to /slack), as it was before any major events.

Code taken from the repo at [this commit](https://github.com/hackclub/site/commit/9db0aec5353c3b9e9c7639491de4b8a1d8b228ea).