### PR TITLE
feat: complete website redesign

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -317,7 +317,7 @@ function Page({
           <Box
             sx={{
               width: '100%',
-              maxWidth: ['100%', '100%', '1500px'],
+              maxWidth: ['100%', '100%', '1200px'],
               px: [3, 4, 4],
               position: 'relative',
               mx: 'auto',


### PR DESCRIPTION
This is the complete website redesign which Zach requested through a bounty made more than a year ago. It's been a long road but I'm so happy we finally got here! The new site features dynamic theming (w/ dark mode), a completely redone navbar, and all-new homepage content sections (live github feed, better open-source examples, and more clear definition of how Hack Club works.

A preview of the redesign can be seen below (might take a while to load in):

welcome to a new era of

```
 _   _            _       ____ _       _     
| | | | __ _  ___| | __  / ___| |_   _| |__  
| |_| |/ _` |/ __| |/ / | |   | | | | | '_ \ 
|  _  | (_| | (__|   <  | |___| | |_| | |_) |
|_| |_|\__,_|\___|_|\_\  \____|_|\__,_|_.__/ 
```

**Preview Image**

<img width="900" height="600" alt="image" src="https://github.com/user-attachments/assets/e8f85c12-457e-45ea-a4d6-6fc9a9ac7009" />
                                                                                                    
-------


Okay, _maybe_ this PR is not quite as major as I made it sound. What actually happened is that I realized that in the process of reverting the fallout hero changes from #1926, I missed an important change which was made to accomodate the video layout: expanding the hero content's maxWidth from 'layout' to '1500px'. 

However, for this change instead of simply reverting back to the 'layout' width (which never really sat right with me as it always felt super horizontally cramped), I thought it would be better to match the width of the navbar with the hero content Box, as illustrated by the comparison timeline below:

**Pre-Fallout Video Hero Width**

<img width="2487" height="1377" alt="Screenshot 2026-04-01 at 21-48-27 A Home for High School Hackers – Hack Club" src="https://github.com/user-attachments/assets/675b8431-38d9-4774-b4fa-5ec8a25cfdd6" />

**Post-Fallout Hero Width (version active on https://hackclub.com right now!)**

<img width="2487" height="1378" alt="Screenshot 2026-04-01 at 21-47-58 A Home for High School Hackers – Hack Club" src="https://github.com/user-attachments/assets/a062854d-e13e-4b57-8651-959a2fd6e095" />

**Improved width (in this PR)**

Benefits:
- More consistent with the overall page width
- Enough breathing room for the heading to not feel too paragraph-y
- A goldilocks middle ground between "too wide" and "too skinny" which is... just right 

<img width="2487" height="1378" alt="Screenshot 2026-04-01 at 21-48-04 A Home for High School Hackers – Hack Club" src="https://github.com/user-attachments/assets/c17da57e-69c1-487d-963d-fd9924702fb8" />
