### PR TITLE
fix: remove image which was not accessible easily

### DIFF
--- a/components/landing/hero.tsx
+++ b/components/landing/hero.tsx
@@ -520,19 +520,6 @@ export function HeroSection() {
             parallaxRate={0.05}
           />
           <Photo
-            src="/assets/hero_photo6.webp"
-            bbX={-100}
-            bbY={695}
-            bbW={390}
-            bbH={290}
-            w={370}
-            h={260}
-            rotate={22}
-            zIndex={8}
-            scale={0.78}
-            parallaxRate={0.04}
-          />
-          <Photo
             src="/assets/hero_photo7.webp"
             bbX={-5}
             bbY={725}

--- a/components/landing/hero.tsx
+++ b/components/landing/hero.tsx
@@ -521,7 +521,7 @@ export function HeroSection() {
           />
           <Photo
             src="/assets/hero_photo7.webp"
-            bbX={-5}
+            bbX={-60}
             bbY={725}
             bbW={390}
             bbH={290}


### PR DESCRIPTION
As stated. Bottom left most image was removed on hero. Updated page looks like this:
<img width="1692" height="961" alt="Screenshot 2026-05-17 at 19 16 49" src="https://github.com/user-attachments/assets/cf5d6543-94b9-4716-9fed-619884c514f3" />
