### PR TITLE
add security.txt to .well-known

### DIFF
--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,5 +1,5 @@
 Contact: mailto:security@hackclub.com
-Expires: 2026-12-31T11:59:00.000Z
+Expires: 2026-12-31T11:59:00Z
 Preferred-Languages: en-US
 Policy: https://security.hackclub.com
 Canonical: https://hackclub.com/.well-known/security.txt

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:security@hackclub.com
+Expires: 2026-12-31T11:59:00.000Z
+Preferred-Languages: en-US
+Policy: https://security.hackclub.com
+Canonical: https://hackclub.com/.well-known/security.txt


### PR DESCRIPTION
Adds a security.txt file at /.well-known/security.txt following RFC 9116. This gives security researchers a standard place to find our disclosure policy and contact info. It looks like the V4 remake removed it at some point with no clear reason, so this adds it back.

Includes:
- Contact: security@hackclub.com
- Expiry date
- Link to security policy at security.hackclub.com