### PR TITLE
docs(conduct): remove dead hackclub.com/night hyperlink

### DIFF
--- a/content/conduct.md
+++ b/content/conduct.md
@@ -26,7 +26,7 @@ If you join in or contribute to the Hack Club ecosystem in any way, you are enco
 Explicit enforcement of the Code of Conduct applies to all official online Hack Club groups, in-person meetings, and events including:
 
 - The [Slack](https://hackclub.com/slack/)
-- The [Events](https://events.hackclub.com/), including [AMAs](https://hackclub.com/amas/), [Hack Night](https://hackclub.com/night/), & Zoom calls on Slack
+- The [Events](https://events.hackclub.com/), including [AMAs](https://hackclub.com/amas/), Hack Night, & Zoom calls on Slack
 - The [GitHub projects](https://github.com/hackclub)
 - Club Meetings
 


### PR DESCRIPTION
## Summary
Fixes #2015 — `https://hackclub.com/night` (and `/night/`) both return **404**.

```diff
- - The [Events](https://events.hackclub.com/), including [AMAs](https://hackclub.com/amas/), [Hack Night](https://hackclub.com/night/), & Zoom calls on Slack
+ - The [Events](https://events.hackclub.com/), including [AMAs](https://hackclub.com/amas/), Hack Night, & Zoom calls on Slack
```

Kept the "Hack Night" name in the line (it's still a real event); just dropped the dead hyperlink. This matches the existing pattern on the same line where "Zoom calls on Slack" is plain text.

Happy to replace with a different live URL instead if there's a current canonical landing page for Hack Night — just let me know which one.

## Verification
- `curl -sLo /dev/null -w '%{http_code}' https://hackclub.com/night/` → `404`
- `curl -sLo /dev/null -w '%{http_code}' https://hackclub.com/night` → `404`

Closes #2015

## Note
Co-developed with AI assistance; reviewed and tested by submitter.