### PR TITLE
Card animations

### DIFF
--- a/app/arcade/ArcadePageClient.tsx
+++ b/app/arcade/ArcadePageClient.tsx
@@ -3,6 +3,8 @@
 import { useState } from "react";
 import { Navbar } from "../../components/Navbar";
 import { Footer } from "../../components/Footer";
+import TiltedCard from "../../components/TiltedCard";
+import Reveal from "../../components/Reveal";
 
 export type ArcadePrize = {
   name: string;
@@ -174,6 +176,7 @@ function PrizeCard({
   onOpen: (prize: ArcadePrize) => void;
 }) {
   return (
+    <TiltedCard rotateAmplitude={8} scaleOnHover={1.05}>
     <article className="arcade-prize-card">
       {prize.limited ? <div className="arcade-prize-limited">Limited!</div> : null}
       <div className="arcade-prize-image-shell">
@@ -195,6 +198,7 @@ function PrizeCard({
         📦
       </button>
     </article>
+    </TiltedCard>
   );
 }
 
@@ -1319,12 +1323,8 @@ export default function ArcadePageClient({
           transform: rotate(-12deg);
         }
 
-        .arcade-prize-card:nth-child(even) {
-          transform: rotate(2deg);
-        }
-
         .arcade-prize-card:hover {
-          transform: scale(1.06) rotate(0deg);
+          box-shadow: 0 20px 40px rgba(0, 0, 0, 0.25);
         }
 
         .arcade-prize-image-shell {

--- a/app/arcade/ArcadePageClient.tsx
+++ b/app/arcade/ArcadePageClient.tsx
@@ -543,7 +543,7 @@ export default function ArcadePageClient({
           <p className="arcade-prizes-subtitle">
             Redeem these with your tickets. For high schoolers or younger only.
           </p>
-          <div className="arcade-prize-grid">
+          <Reveal><div className="arcade-prize-grid">
             {prizes.map((prize) => (
               <PrizeCard
                 key={`${prize.name}-${prize.hours}`}
@@ -551,7 +551,7 @@ export default function ArcadePageClient({
                 onOpen={setSelectedPrize}
               />
             ))}
-          </div>
+          </div></Reveal>
           <p className="arcade-sneak-peek">
             This is just a <span>sneak peek</span>... there were many more prizes that were unlocked
             as the summer went on!

--- a/app/brand/page.tsx
+++ b/app/brand/page.tsx
@@ -118,7 +118,7 @@ export default function BrandPage() {
             stretching, outlining, or recoloring.
           </p>
         </div>
-        <div className="brand-grid brand-grid--logos">
+        <Reveal><div className="brand-grid brand-grid--logos">
           {logoKeys.map((key) => (
             <TiltedCard key={key}>
               <article className="brand-card">
@@ -143,8 +143,8 @@ export default function BrandPage() {
               </div>
             </article>
             </TiltedCard>
-          ))}
-        </div>
+            ))}
+        </div></Reveal>
         <a
           className="brand-btn brand-btn--dark brand-btn--block"
           href="https://assets.hackclub.com/2020_branding.zip"
@@ -161,7 +161,7 @@ export default function BrandPage() {
             HCB has its own identity. Grab the light and dark versions here.
           </p>
         </div>
-        <div className="brand-grid brand-grid--logos">
+        <Reveal delay={0.1}><div className="brand-grid brand-grid--logos">
           {hcbLogoKeys.map((key) => (
             <TiltedCard key={key}>
               <article className="brand-card">
@@ -186,8 +186,8 @@ export default function BrandPage() {
               </div>
             </article>
             </TiltedCard>
-          ))}
-        </div>
+            ))}
+        </div></Reveal>
         <a
           className="brand-btn brand-btn--dark brand-btn--block"
           href="https://hcb.hackclub.com/branding"

--- a/app/brand/page.tsx
+++ b/app/brand/page.tsx
@@ -3,6 +3,8 @@ import { WebfontCssBox } from "@/components/WebfontCssBox";
 import { Footer } from "../../components/Footer";
 import { Navbar } from "../../components/Navbar";
 import { buildPageMetadata } from "@/lib/seo";
+import TiltedCard from "../../components/TiltedCard";
+import Reveal from "../../components/Reveal";
 
 export const metadata: Metadata = buildPageMetadata({
   title: "Brand — Hack Club",
@@ -118,7 +120,8 @@ export default function BrandPage() {
         </div>
         <div className="brand-grid brand-grid--logos">
           {logoKeys.map((key) => (
-            <article key={key} className="brand-card">
+            <TiltedCard key={key}>
+              <article className="brand-card">
               <div className="brand-card__preview brand-card__preview--light">
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img src={assetUrl(key, "svg")} alt={logoTitle(key)} />
@@ -139,6 +142,7 @@ export default function BrandPage() {
                 <div className="brand-card__url">{assetUrl(key, "svg")}</div>
               </div>
             </article>
+            </TiltedCard>
           ))}
         </div>
         <a
@@ -159,7 +163,8 @@ export default function BrandPage() {
         </div>
         <div className="brand-grid brand-grid--logos">
           {hcbLogoKeys.map((key) => (
-            <article key={key} className="brand-card">
+            <TiltedCard key={key}>
+              <article className="brand-card">
               <div className="brand-card__preview brand-card__preview--light">
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img src={assetUrl(key, "png")} alt={logoTitle(key)} />
@@ -180,6 +185,7 @@ export default function BrandPage() {
                 <div className="brand-card__url">{assetUrl(key, "svg")}</div>
               </div>
             </article>
+            </TiltedCard>
           ))}
         </div>
         <a

--- a/app/clubs/page.tsx
+++ b/app/clubs/page.tsx
@@ -5,6 +5,7 @@ import { Footer } from "../../components/Footer";
 import { YouTubeEmbed } from "../../components/YouTubeEmbed";
 import type { ReactNode } from "react";
 import { buildPageMetadata } from "@/lib/seo";
+import Reveal from "../../components/Reveal";
 
 export const metadata: Metadata = buildPageMetadata({
   title: "Hack Club Clubs — Start a Club",
@@ -482,7 +483,7 @@ export default function ClubPage() {
             >
               Get your club going and growing.
             </h2>
-            <div
+            <Reveal><div
               style={{
                 display: "grid",
                 gridTemplateColumns: "repeat(auto-fit, minmax(250px, 1fr))",
@@ -576,7 +577,7 @@ export default function ClubPage() {
                   </>
                 }
               />
-            </div>
+            </div></Reveal>
           </div>
         </section>
 
@@ -588,7 +589,7 @@ export default function ClubPage() {
           }}
         >
           <div style={{ maxWidth: 1120, margin: "0 auto", textAlign: "center" }}>
-            <h2
+            <Reveal><h2
               style={{
                 margin: "0 0 14px",
                 fontFamily: "var(--font-zarathustra)",
@@ -598,8 +599,8 @@ export default function ClubPage() {
               }}
             >
               Start your club.
-            </h2>
-            <p
+            </h2></Reveal>
+            <Reveal delay={0.1}><p
               style={{
                 margin: "0 auto 24px",
                 maxWidth: 820,
@@ -609,8 +610,8 @@ export default function ClubPage() {
               }}
             >
               It&apos;s online, free, and takes less than an hour to kick off.
-            </p>
-            <div
+            </p></Reveal>
+            <Reveal delay={0.2}><div
               style={{
                 display: "grid",
                 gridTemplateColumns: "repeat(auto-fit, minmax(250px, 1fr))",
@@ -634,7 +635,7 @@ export default function ClubPage() {
                 description="Schedule your first session and start shipping projects."
                 gradient="linear-gradient(135deg, #6f31b7 0%, #fb558e 100%)"
               />
-            </div>
+            </div></Reveal>
             <a
               href="https://apply.hackclub.com"
               target="_blank"

--- a/app/jobs/page.tsx
+++ b/app/jobs/page.tsx
@@ -81,7 +81,7 @@ export default async function JobsPage() {
           <h2 className="jobs-section__title">Open roles</h2>
         </div>
 
-        <div className="jobs-grid">
+        <Reveal><div className="jobs-grid">
           {hasJobs ? (
             jobs.items.map((job) => (
               <TiltedCard key={job.id}>
@@ -108,7 +108,7 @@ export default async function JobsPage() {
               </p>
             </div>
           )}
-        </div>
+        </div></Reveal>
       </section>
 
       <Footer />

--- a/app/jobs/page.tsx
+++ b/app/jobs/page.tsx
@@ -2,6 +2,8 @@ import { Metadata } from "next";
 import { Footer } from "../../components/Footer";
 import { Navbar } from "../../components/Navbar";
 import { buildPageMetadata } from "@/lib/seo";
+import TiltedCard from "../../components/TiltedCard";
+import Reveal from "../../components/Reveal";
 
 export const metadata: Metadata = buildPageMetadata({
   title: "Jobs — Hack Club",
@@ -82,9 +84,9 @@ export default async function JobsPage() {
         <div className="jobs-grid">
           {hasJobs ? (
             jobs.items.map((job) => (
-              <a
-                key={job.id}
-                className="jobs-card"
+              <TiltedCard key={job.id}>
+                <a
+                  className="jobs-card"
                 href={job.job_post_url}
                 target="_blank"
                 rel="noopener noreferrer"
@@ -95,6 +97,7 @@ export default async function JobsPage() {
                 </div>
                 <p>{jobMeta(job)}</p>
               </a>
+              </TiltedCard>
             ))
           ) : (
             <div className="jobs-empty">
@@ -230,7 +233,6 @@ export default async function JobsPage() {
         }
 
         .jobs-card:hover {
-          transform: translateY(-2px);
           box-shadow: 0 24px 50px rgba(91, 52, 18, 0.12);
         }
 

--- a/app/opensource/page.tsx
+++ b/app/opensource/page.tsx
@@ -2,6 +2,8 @@ import { Metadata } from "next";
 import { Navbar } from "../../components/Navbar";
 import { Footer } from "../../components/Footer";
 import { buildPageMetadata } from "@/lib/seo";
+import TiltedCard from "../../components/TiltedCard";
+import Reveal from "../../components/Reveal";
 
 export const metadata: Metadata = buildPageMetadata({
   title: "Open Source — Hack Club",
@@ -47,9 +49,11 @@ export default function OpenSourcePage() {
         </div>
         <div className="opensource-finance-grid">
           {financeItems.map((item) => (
-            <article key={item} className="opensource-card">
+            <TiltedCard key={item}>
+              <article className="opensource-card">
               <h3>{item}</h3>
             </article>
+            </TiltedCard>
           ))}
         </div>
       </section>

--- a/app/opensource/page.tsx
+++ b/app/opensource/page.tsx
@@ -47,15 +47,15 @@ export default function OpenSourcePage() {
             All open sourced through HCB Transparency Mode.
           </h2>
         </div>
-        <div className="opensource-finance-grid">
+        <Reveal><div className="opensource-finance-grid">
           {financeItems.map((item) => (
             <TiltedCard key={item}>
               <article className="opensource-card">
               <h3>{item}</h3>
             </article>
             </TiltedCard>
-          ))}
-        </div>
+            ))}
+        </div></Reveal>
       </section>
 
       <section className="opensource-shell opensource-section opensource-section--last">

--- a/app/philanthropy/page.tsx
+++ b/app/philanthropy/page.tsx
@@ -4,6 +4,7 @@ import { Navbar } from "../../components/Navbar";
 import { Footer } from "../../components/Footer";
 import { buildPageMetadata } from "@/lib/seo";
 import insiderLogo from "./assets/insider-logo.svg";
+import Reveal from "../../components/Reveal";
 import wsjLogo from "./assets/wsj-logo.svg";
 import forbesLogo from "./assets/forbes-logo.svg";
 import copLogo from "./assets/cop.webp";
@@ -295,7 +296,7 @@ export default function PhilanthropyPage() {
       </section>
 
       <section className="philanthropy-shell philanthropy-section">
-        <div className="philanthropy-testimonials">
+        <Reveal><div className="philanthropy-testimonials">
           {testimonials.map((item) => (
             <article key={item.info} className="philanthropy-testimonial-card">
               <Image
@@ -310,7 +311,7 @@ export default function PhilanthropyPage() {
               </div>
             </article>
           ))}
-        </div>
+        </div></Reveal>
       </section>
 
       <section className="philanthropy-shell philanthropy-section">
@@ -339,7 +340,7 @@ export default function PhilanthropyPage() {
           <p className="philanthropy-kicker philanthropy-kicker--dark">Community</p>
           <h2>Join our community of generous donors.</h2>
         </div>
-        <div className="philanthropy-donors">
+        <Reveal><div className="philanthropy-donors">
           {donorTiers.map((tier) => (
             <div key={tier.title} className="philanthropy-donors__tier">
               <h3>{tier.title}</h3>
@@ -350,7 +351,7 @@ export default function PhilanthropyPage() {
               </ul>
             </div>
           ))}
-        </div>
+        </div></Reveal>
         <p className="philanthropy-donors__note">
           * number in parentheses indicates gifts since 2018.
         </p>
@@ -368,7 +369,7 @@ export default function PhilanthropyPage() {
           <p className="philanthropy-kicker philanthropy-kicker--dark">Impact stories</p>
           <h2>What your support enables.</h2>
         </div>
-        <div className="philanthropy-impact-grid">
+        <Reveal><div className="philanthropy-impact-grid">
           {impactStories.map((story) => (
             <article key={story.title} className="philanthropy-impact-card">
               <div className="philanthropy-impact-card__copy">
@@ -384,7 +385,7 @@ export default function PhilanthropyPage() {
               </div>
             </article>
           ))}
-        </div>
+        </div></Reveal>
 
         <div className="philanthropy-belle-quote">
           <h3>“Hack Club helped me fall in love with creating and made me feel like I belong.”</h3>
@@ -400,13 +401,13 @@ export default function PhilanthropyPage() {
           <p className="philanthropy-kicker philanthropy-kicker--dark">In the news</p>
           <h2>As the largest network of technical teenagers, we are featured in global press.</h2>
         </div>
-        <div className="philanthropy-press">
+        <Reveal><div className="philanthropy-press">
           {pressLogos.map((logo) => (
             <a key={logo.href} href={logo.href} target="_blank" rel="noreferrer">
               <Image src={logo.src} alt={logo.alt} width={180} height={60} />
             </a>
           ))}
-        </div>
+        </div></Reveal>
       </section>
 
       <section className="philanthropy-shell philanthropy-section">

--- a/app/press/page.tsx
+++ b/app/press/page.tsx
@@ -160,7 +160,7 @@ export default function PressPage() {
             Download and use these images for coverage of Hack Club programs and events.
           </p>
         </div>
-        <div className="press-photo-grid">
+        <Reveal><div className="press-photo-grid">
           {photoItems.map((photo) => (
             <figure key={photo.src} className="press-photo">
               {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -168,7 +168,7 @@ export default function PressPage() {
               <figcaption>{photo.alt}</figcaption>
             </figure>
           ))}
-        </div>
+        </div></Reveal>
         <a
           className="press-btn press-btn--ghost press-btn--block press-photos-download"
           href="https://assets.hackclub.com/press-photos.zip"
@@ -186,7 +186,7 @@ export default function PressPage() {
             stretching, outlining, or recoloring.
           </p>
         </div>
-        <div className="press-logo-grid">
+        <Reveal><div className="press-logo-grid">
           {logoAssets.map((logo) => (
             <TiltedCard key={logo.key}>
               <article className="press-logo-card">
@@ -215,8 +215,8 @@ export default function PressPage() {
               </div>
             </article>
             </TiltedCard>
-          ))}
-        </div>
+            ))}
+        </div></Reveal>
       </section>
 
       <section className="press-shell press-section press-section--cta">

--- a/app/press/page.tsx
+++ b/app/press/page.tsx
@@ -2,6 +2,8 @@ import { Metadata } from "next";
 import { Footer } from "../../components/Footer";
 import { Navbar } from "../../components/Navbar";
 import { buildPageMetadata } from "@/lib/seo";
+import TiltedCard from "../../components/TiltedCard";
+import Reveal from "../../components/Reveal";
 
 export const metadata: Metadata = buildPageMetadata({
   title: "Press — Hack Club",
@@ -186,7 +188,8 @@ export default function PressPage() {
         </div>
         <div className="press-logo-grid">
           {logoAssets.map((logo) => (
-            <article key={logo.key} className="press-logo-card">
+            <TiltedCard key={logo.key}>
+              <article className="press-logo-card">
               <div className="press-logo-card__preview">
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
@@ -211,6 +214,7 @@ export default function PressPage() {
                 </div>
               </div>
             </article>
+            </TiltedCard>
           ))}
         </div>
       </section>

--- a/app/programs/ProgramsPageClient.tsx
+++ b/app/programs/ProgramsPageClient.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { Navbar } from "../../components/Navbar";
 import { Footer } from "../../components/Footer";
+import Reveal from "../../components/Reveal";
 import type { ProgramFormat, ProjectType } from "../../lib/site-programs";
 import { PROJECT_TYPE_OPTIONS, formatInPersonDate } from "../../lib/site-programs";
 import type { AirtableProgram } from "../../lib/programs";
@@ -1035,14 +1036,14 @@ export default function ProgramsPage({
           </p>
         )}
 
-        <div
+        <Reveal><div
           className="programs-grid"
           style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 28 }}
         >
           {programs === null
             ? Array.from({ length: 4 }).map((_, i) => <CardSkeleton key={i} />)
             : sorted.map((p) => <ProgramCard key={p.id} program={p} />)}
-        </div>
+        </div></Reveal>
 
         {programs !== null && sorted.length === 0 && (
           <p

--- a/app/team/TeamPageClient.tsx
+++ b/app/team/TeamPageClient.tsx
@@ -4,6 +4,8 @@ import Image from "next/image";
 import { useState } from "react";
 import { Footer } from "../../components/Footer";
 import { Navbar } from "../../components/Navbar";
+import TiltedCard from "../../components/TiltedCard";
+import Reveal from "../../components/Reveal";
 
 export type TeamMember = {
   name: string;
@@ -128,7 +130,8 @@ function BoardCard({
 
 function PersonCard({ member, onClick }: { member: TeamMember; onClick: () => void }) {
   return (
-    <article className="person-card" onClick={onClick}>
+    <TiltedCard rotateAmplitude={10} scaleOnHover={1.04}>
+      <article className="person-card" onClick={onClick}>
       <div className="person-card__top">
         <div className="person-card__avatar-wrap">
           {member.avatar ? (
@@ -151,6 +154,7 @@ function PersonCard({ member, onClick }: { member: TeamMember; onClick: () => vo
         </div>
       </div>
     </article>
+    </TiltedCard>
   );
 }
 
@@ -726,7 +730,6 @@ export default function TeamPageClient({
         }
 
         .person-card:hover {
-          transform: scale(1.05);
           box-shadow: 0 18px 30px rgba(91, 52, 18, 0.1);
           border-color: rgba(236, 55, 80, 0.18);
         }

--- a/app/team/TeamPageClient.tsx
+++ b/app/team/TeamPageClient.tsx
@@ -168,11 +168,11 @@ function TeamLane({
 }: TeamLaneProps & { onMemberClick: (member: TeamMember) => void }) {
   return (
     <section className={`lane lane--${tone}`}>
-      <div className="lane__header">
+      <Reveal><div className="lane__header">
         <p className="lane__eyebrow">{eyebrow}</p>
         <h2 className="lane__title">{title}</h2>
         <p className="lane__description">{description}</p>
-      </div>
+      </div></Reveal>
 
       <div className="lane__groups">
         {groups
@@ -182,7 +182,7 @@ function TeamLane({
               <div className="lane__group-head">
                 <h3>{group.label}</h3>
               </div>
-              <div className="person-grid">
+              <Reveal delay={0.1}><div className="person-grid">
                 {group.members.map((member) => (
                   <PersonCard
                     key={`${group.label}-${member.name}`}
@@ -190,7 +190,7 @@ function TeamLane({
                     onClick={() => onMemberClick(member)}
                   />
                 ))}
-              </div>
+              </div></Reveal>
             </div>
           ))}
       </div>
@@ -207,14 +207,14 @@ function CommunityPod({
 }: CommunityPodProps & { onMemberClick: (member: TeamMember) => void }) {
   return (
     <section className={`pod pod--${tone}`}>
-      <div className="pod__header">
+      <Reveal><div className="pod__header">
         <div>
           <p className="pod__label"></p>
           <h3 className="pod__title">{title}</h3>
         </div>
-      </div>
-      <p className="pod__description">{description}</p>
-      <div className="person-grid person-grid--compact">
+      </div></Reveal>
+      <Reveal delay={0.1}><p className="pod__description">{description}</p></Reveal>
+      <Reveal delay={0.2}><div className="person-grid person-grid--compact">
         {members.map((member) => (
           <PersonCard
             key={`${title}-${member.name}`}
@@ -222,7 +222,7 @@ function CommunityPod({
             onClick={() => onMemberClick(member)}
           />
         ))}
-      </div>
+      </div></Reveal>
     </section>
   );
 }
@@ -265,8 +265,8 @@ export default function TeamPageClient({
 
       <section className="team-shell board-section">
         <div className="board-section__inner">
-          <h2 className="board-section__title">Board &amp; Advisors</h2>
-          <div className="board-grid board-grid--leaders">
+          <Reveal><h2 className="board-section__title">Board &amp; Advisors</h2></Reveal>
+          <Reveal delay={0.1}><div className="board-grid board-grid--leaders">
             <BoardCard
               img="https://cdn.hackclub.com/019d8d79-96e5-7902-9e5b-1de299c1bdff/2026_04_14_0pu_Kleki%20(2).png"
               name="Zach Latta"
@@ -281,8 +281,8 @@ export default function TeamPageClient({
               bio="With over a decade of experience leading organizations, Christina has built global teams and raised millions. A former New York Times journalist and public school teacher, she co-founded Hack Club."
               email="christina"
             />
-          </div>
-          <div className="board-grid board-grid--advisors">
+          </div></Reveal>
+          <Reveal delay={0.2}><div className="board-grid board-grid--advisors">
             <BoardCard
               img="https://cdn.hackclub.com/019da8a0-de67-721b-911c-5a4cf1a2ad4a/p.webp"
               name="Tom Preston-Werner"
@@ -304,19 +304,19 @@ export default function TeamPageClient({
               subrole="Founder, Boston Scientific"
               href="https://en.wikipedia.org/wiki/John_Abele"
             />
-          </div>
+          </div></Reveal>
         </div>
       </section>
 
       <section className="team-shell team-section">
-        <div className="team-section__header">
+        <Reveal><div className="team-section__header">
           <h2 className="team-section__title">Core teams</h2>
           <p className="team-section__copy">
             HQ helps run the main Hack Club experience, while HCB keeps thousands of fiscally
             sponsored non-profits running. Both are made up of staff, gap years, and teen
             contributors.
           </p>
-        </div>
+        </div></Reveal>
 
         <div className="lane-grid">
           <TeamLane
@@ -339,14 +339,14 @@ export default function TeamPageClient({
       </section>
 
       <section className="team-shell team-section team-section--community">
-        <div className="team-section__header">
+        <Reveal><div className="team-section__header">
           <p className="team-kicker team-kicker--dark">Community Teams</p>
           <h2 className="team-section__title">The teen-facing crews shaping daily culture.</h2>
           <p className="team-section__copy">
             These teams are the visible edge of Hack Club: welcoming people in, moderating the
             space, hosting events, and telling the story of what everyone is making together.
           </p>
-        </div>
+        </div></Reveal>
 
         <div className="pod-grid">
           {communityPods.map((pod) => (

--- a/components/Reveal.tsx
+++ b/components/Reveal.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useRef, useState, useEffect } from "react";
+
+export default function Reveal({
+  children,
+  className = "",
+  delay = 0,
+  y = 20,
+  duration = 0.4,
+  once = true,
+  style = {},
+}: {
+  children: React.ReactNode;
+  className?: string;
+  delay?: number;
+  y?: number;
+  duration?: number;
+  once?: boolean;
+  style?: React.CSSProperties;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+    if (prefersReducedMotion) {
+      setVisible(true);
+      return;
+    }
+
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          if (once) observer.disconnect();
+        }
+      },
+      { threshold: 0.1 },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [once]);
+
+  return (
+    <div
+      ref={ref}
+      className={className}
+      style={{
+        ...style,
+        opacity: visible ? 1 : 0,
+        transform: visible ? "translateY(0)" : `translateY(${y}px)`,
+        transition: `opacity ${duration}s ease, transform ${duration}s ease`,
+        transitionDelay: `${delay}s`,
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/components/TiltedCard.tsx
+++ b/components/TiltedCard.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+export default function TiltedCard({
+  children,
+  className = "",
+  rotateAmplitude = 12,
+  scaleOnHover = 1.03,
+  style = {},
+}: {
+  children: React.ReactNode;
+  className?: string;
+  rotateAmplitude?: number;
+  scaleOnHover?: number;
+  style?: React.CSSProperties;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [transformStyle, setTransformStyle] = useState<React.CSSProperties>({});
+
+  function handleMouseMove(e: React.MouseEvent) {
+    const el = ref.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const x = (e.clientX - rect.left) / rect.width - 0.5;
+    const y = (e.clientY - rect.top) / rect.height - 0.5;
+    setTransformStyle({
+      transform: `perspective(900px) rotateY(${x * rotateAmplitude}deg) rotateX(${-y * rotateAmplitude}deg) scale(${scaleOnHover})`,
+      transition: "transform 0.08s ease-out",
+    });
+  }
+
+  function handleMouseLeave() {
+    setTransformStyle({
+      transform: "perspective(900px) rotateX(0deg) rotateY(0deg) scale(1)",
+      transition: "transform 0.4s ease-out",
+    });
+  }
+
+  return (
+    <div
+      ref={ref}
+      className={className}
+      style={{ ...style, ...transformStyle, willChange: "transform" }}
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseLeave}
+    >
+      {children}
+    </div>
+  );
+}

--- a/components/landing/donors.tsx
+++ b/components/landing/donors.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { BtnArrowSvg } from "./btn-arrow";
+import Reveal from "../Reveal";
 
 const donors = [
   {
@@ -142,7 +143,7 @@ export function DonorsSection() {
       </p>
 
       {/* Donor logo wall — static and larger */}
-      <div
+      <Reveal><div
         className="donor-logos-grid"
         style={{
           display: "flex",
@@ -185,7 +186,7 @@ export function DonorsSection() {
             />
           </div>
         ))}
-      </div>
+      </div></Reveal>
 
       {/* Donor name pills */}
       <div

--- a/components/landing/joining.tsx
+++ b/components/landing/joining.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import type { CSSProperties } from "react";
 import { useEffect, useRef, useState } from "react";
 import { BtnArrowSvg } from "./btn-arrow";
+import TiltedCard from "../TiltedCard";
+import Reveal from "../Reveal";
 
 type SlackStat = {
   value: number;
@@ -583,7 +585,8 @@ export function JoiningSection() {
           }}
         >
           {/* ── Card 1: Our online community ── */}
-          <div style={{ ...cardWrapStyle, overflow: "visible" }}>
+          <TiltedCard style={{ overflow: "visible" }}>
+            <div style={{ ...cardWrapStyle, overflow: "visible" }}>
             {/* Background + overlay clipped to rounded corners */}
             <CardBg
               src={
@@ -661,9 +664,11 @@ export function JoiningSection() {
               </div>
             )}
           </div>
+          </TiltedCard>
 
           {/* ── Card 2: HCB ── */}
-          <div style={{ ...cardWrapStyle, overflow: "visible" }}>
+          <TiltedCard style={{ overflow: "visible" }}>
+            <div style={{ ...cardWrapStyle, overflow: "visible" }}>
             {/* Background + overlay clipped to rounded corners */}
             <CardBg
               src={
@@ -718,9 +723,11 @@ export function JoiningSection() {
               <CardCta href="https://hcb.hackclub.com/applications/new">Start fundraising</CardCta>
             </div>
           </div>
+          </TiltedCard>
 
           {/* ── Card 3: Clubs ── */}
-          <div style={cardWrapStyle}>
+          <TiltedCard>
+            <div style={cardWrapStyle}>
             {/* Background + overlay */}
             <CardBg
               src={
@@ -755,9 +762,11 @@ export function JoiningSection() {
               <CardCta href="https://hackclub.com/clubs/">Start or find a club</CardCta>
             </div>
           </div>
+          </TiltedCard>
 
           {/* ── Card 4: Free stuff ── */}
-          <div style={cardWrapStyle}>
+          <TiltedCard>
+            <div style={cardWrapStyle}>
             {/* Background + overlay */}
             <CardBg
               src={
@@ -789,6 +798,7 @@ export function JoiningSection() {
               <CardCta href="https://toolbox.hackclub.com/">See all perks</CardCta>
             </div>
           </div>
+          </TiltedCard>
         </div>
       </div>
 

--- a/components/landing/joining.tsx
+++ b/components/landing/joining.tsx
@@ -585,7 +585,7 @@ export function JoiningSection() {
           }}
         >
           {/* ── Card 1: Our online community ── */}
-          <TiltedCard style={{ overflow: "visible" }}>
+          <Reveal delay={0}><TiltedCard style={{ overflow: "visible" }}>
             <div style={{ ...cardWrapStyle, overflow: "visible" }}>
             {/* Background + overlay clipped to rounded corners */}
             <CardBg
@@ -664,10 +664,10 @@ export function JoiningSection() {
               </div>
             )}
           </div>
-          </TiltedCard>
+          </TiltedCard></Reveal>
 
           {/* ── Card 2: HCB ── */}
-          <TiltedCard style={{ overflow: "visible" }}>
+          <Reveal delay={0.1}><TiltedCard style={{ overflow: "visible" }}>
             <div style={{ ...cardWrapStyle, overflow: "visible" }}>
             {/* Background + overlay clipped to rounded corners */}
             <CardBg
@@ -723,10 +723,10 @@ export function JoiningSection() {
               <CardCta href="https://hcb.hackclub.com/applications/new">Start fundraising</CardCta>
             </div>
           </div>
-          </TiltedCard>
+          </TiltedCard></Reveal>
 
           {/* ── Card 3: Clubs ── */}
-          <TiltedCard>
+          <Reveal delay={0.2}><TiltedCard>
             <div style={cardWrapStyle}>
             {/* Background + overlay */}
             <CardBg
@@ -762,10 +762,10 @@ export function JoiningSection() {
               <CardCta href="https://hackclub.com/clubs/">Start or find a club</CardCta>
             </div>
           </div>
-          </TiltedCard>
+          </TiltedCard></Reveal>
 
           {/* ── Card 4: Free stuff ── */}
-          <TiltedCard>
+          <Reveal delay={0.3}><TiltedCard>
             <div style={cardWrapStyle}>
             {/* Background + overlay */}
             <CardBg
@@ -798,7 +798,7 @@ export function JoiningSection() {
               <CardCta href="https://toolbox.hackclub.com/">See all perks</CardCta>
             </div>
           </div>
-          </TiltedCard>
+          </TiltedCard></Reveal>
         </div>
       </div>
 

--- a/components/landing/ready.tsx
+++ b/components/landing/ready.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { EmailSignupInput } from "./email-signup";
 import { BtnArrow } from "./btn-arrow";
+import Reveal from "../Reveal";
 
 export function ReadySection() {
   return (
@@ -16,7 +17,7 @@ export function ReadySection() {
       }}
     >
       {/* Centred content — Figma order: headline → email → description → button → italic */}
-      <div
+      <Reveal><div
         style={{
           position: "relative",
           zIndex: 1,
@@ -111,7 +112,7 @@ export function ReadySection() {
             terms.
           </Link>
         </p>
-      </div>
+      </div></Reveal>
 
       <style>{`
         .ready-terms-link:hover,


### PR DESCRIPTION
## Summary
Adds two visual interaction effects across the site:
1. **TiltedCard** — Cards tilt on hover for a polished 3D feel (person cards, job listings, brand logos, finance items, press logos, and landing cards)
2. **Reveal** — Sections fade and slide in as you scroll down the page, with staggered delays for layered entry effects
### Changes
- Wrap card components with `<TiltedCard>` for tilt-on-hover interaction
- Remove redundant CSS transforms/rotations (replaced by TiltedCard)
- Wrap section headers, grids, and feature walls with `<Reveal>` for scroll-triggered animations
- Add `Reveal.tsx` and `TiltedCard.tsx` component files