### PR TITLE
Reduce hover delay from 300ms to 10ms

### DIFF
--- a/components/landing/hero.tsx
+++ b/components/landing/hero.tsx
@@ -751,7 +751,7 @@ export function HeroSection() {
             pointerEvents: "auto",
           }}
           onMouseEnter={() => {
-            magHoverTimer.current = setTimeout(() => setMagHover("in"), 300);
+            magHoverTimer.current = setTimeout(() => setMagHover("in"), 10);
           }}
           onMouseLeave={() => {
             if (magHoverTimer.current) clearTimeout(magHoverTimer.current);


### PR DESCRIPTION
I changed the hover delay on the new stardance link on the main page from 300ms to 10ms as I thought it was a bit disturbing the way it took time for the hover to come.