### PR TITLE
fix(team): correct truncated field name 'bioHackFoundatio' to 'bioHackFoundation'

### DIFF
--- a/public/team.json
+++ b/public/team.json
@@ -674,7 +674,7 @@
     "role": "Engineering",
     "acknowledged": false,
     "bio": "Euan learned to code to automate a boring job at 16, He realised he loved coding and making so started to teach robotics to younger kids and now is building programs to teach kids all around the world at Hack Club",
-    "bioHackFoundatio": "",
+    "bioHackFoundation": "",
     "slackId": "U06T30DNB3L",
     "email": "euan",
     "website": "",


### PR DESCRIPTION
## What

Fixes a truncated JSON field name in `public/team.json`.

Line 677 had `"bioHackFoundatio"` instead of `"bioHackFoundation"`, making it an inconsistent/orphaned key that doesn't match the field used elsewhere in the file (e.g. line 654).

## Why

The truncated key would be silently ignored by any code reading this field, meaning the data is effectively lost. This brings it in line with the correct field name used by other team members.