### PR TITLE
fix(email field): Email field fixing

### DIFF
--- a/components/landing/email-signup.tsx
+++ b/components/landing/email-signup.tsx
@@ -97,7 +97,7 @@ export function EmailSignupInput({ variant = "hero" }: EmailSignupInputProps) {
           id={c.inputId}
           type="email"
           aria-label="Email address"
-          placeholder="orpheus@email.com"
+          placeholder="orpheus@example.com"
           value={e}
           onChange={(ev) => {
             setE(ev.target.value);
@@ -185,7 +185,7 @@ export function EmailSignupInput({ variant = "hero" }: EmailSignupInputProps) {
             boxShadow: "0 4px 12px rgba(236,55,80,0.3)",
           }}
         >
-          Enter Valid email
+          Enter a valid email address
           <div
             style={{
               position: "absolute",


### PR DESCRIPTION
## "email.com" -> "example.com"
[email.com](https://email.com) is a real domain name. The Internet Engineering Task Force (through [RFC 6761](https://www.rfc-editor.org/info/rfc6761/#section-6.5)) thankfully reserved example.com as an example domain name. In other words, because the domain is not "real", we can't get in trouble.

(I know other websites use email.com, but seriously. The all-your-friends-jumping-off-a-cliff cliché actually applies here.)

## "Enter Valid email" -> "Enter a valid email address"
Grammar and capitalization; sentence case should be used here. Also, to reduce ambiguity, I added "a valid" and "email address."