### PR TITLE
Add parents page email signup wired to Airtable

### DIFF
--- a/app/api/parents-signup/route.ts
+++ b/app/api/parents-signup/route.ts
@@ -18,6 +18,27 @@ function clientIp(req: NextRequest) {
   return req.headers.get("x-real-ip") ?? undefined;
 }
 
+const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
+const RATE_LIMIT_MAX = 5;
+const rateLimitHits = new Map<string, number[]>();
+
+function isRateLimited(key: string) {
+  const now = Date.now();
+  const recent = (rateLimitHits.get(key) ?? []).filter(
+    (t) => now - t < RATE_LIMIT_WINDOW_MS,
+  );
+  recent.push(now);
+  rateLimitHits.set(key, recent);
+
+  if (rateLimitHits.size > 5000) {
+    for (const [k, hits] of rateLimitHits) {
+      if (now - hits[hits.length - 1] > RATE_LIMIT_WINDOW_MS) rateLimitHits.delete(k);
+    }
+  }
+
+  return recent.length > RATE_LIMIT_MAX;
+}
+
 export async function POST(req: NextRequest) {
   const key = apiKey();
   if (!key) {
@@ -37,6 +58,10 @@ export async function POST(req: NextRequest) {
   }
 
   const ip = clientIp(req);
+
+  if (isRateLimited(ip ?? "unknown")) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
 
   const res = await fetch(
     `https://api.airtable.com/v0/${BASE_ID}/${encodeURIComponent(TABLE_NAME)}`,

--- a/app/api/parents-signup/route.ts
+++ b/app/api/parents-signup/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { blockBotRequest } from "@/lib/botid";
 
 export const dynamic = "force-dynamic";
 
@@ -18,28 +19,10 @@ function clientIp(req: NextRequest) {
   return req.headers.get("x-real-ip") ?? undefined;
 }
 
-const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
-const RATE_LIMIT_MAX = 5;
-const rateLimitHits = new Map<string, number[]>();
-
-function isRateLimited(key: string) {
-  const now = Date.now();
-  const recent = (rateLimitHits.get(key) ?? []).filter(
-    (t) => now - t < RATE_LIMIT_WINDOW_MS,
-  );
-  recent.push(now);
-  rateLimitHits.set(key, recent);
-
-  if (rateLimitHits.size > 5000) {
-    for (const [k, hits] of rateLimitHits) {
-      if (now - hits[hits.length - 1] > RATE_LIMIT_WINDOW_MS) rateLimitHits.delete(k);
-    }
-  }
-
-  return recent.length > RATE_LIMIT_MAX;
-}
-
 export async function POST(req: NextRequest) {
+  const blocked = await blockBotRequest();
+  if (blocked) return blocked;
+
   const key = apiKey();
   if (!key) {
     return NextResponse.json({ error: "PARENTS_AIRTABLE_KEY is not set" }, { status: 500 });
@@ -58,10 +41,6 @@ export async function POST(req: NextRequest) {
   }
 
   const ip = clientIp(req);
-
-  if (isRateLimited(ip ?? "unknown")) {
-    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
-  }
 
   const res = await fetch(
     `https://api.airtable.com/v0/${BASE_ID}/${encodeURIComponent(TABLE_NAME)}`,

--- a/app/api/parents-signup/route.ts
+++ b/app/api/parents-signup/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+const BASE_ID = "applbij4WGNtixmE4";
+const TABLE_NAME = "signup";
+
+function apiKey() {
+  return process.env.PARENTS_AIRTABLE_KEY;
+}
+
+const isValidEmail = (v: unknown): v is string =>
+  typeof v === "string" && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v.trim());
+
+function clientIp(req: NextRequest) {
+  const forwardedFor = req.headers.get("x-forwarded-for");
+  if (forwardedFor) return forwardedFor.split(",")[0].trim();
+  return req.headers.get("x-real-ip") ?? undefined;
+}
+
+export async function POST(req: NextRequest) {
+  const key = apiKey();
+  if (!key) {
+    return NextResponse.json({ error: "PARENTS_AIRTABLE_KEY is not set" }, { status: 500 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const email = (body as { email?: unknown })?.email;
+  if (!isValidEmail(email)) {
+    return NextResponse.json({ error: "Invalid email address" }, { status: 400 });
+  }
+
+  const ip = clientIp(req);
+
+  const res = await fetch(
+    `https://api.airtable.com/v0/${BASE_ID}/${encodeURIComponent(TABLE_NAME)}`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        records: [{ fields: { email: email.trim(), ...(ip ? { ip } : {}) } }],
+      }),
+    },
+  );
+
+  if (!res.ok) {
+    console.error("[parents-signup] Airtable error", res.status, await res.text());
+    return NextResponse.json({ error: "Failed to save signup" }, { status: 502 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/parents-signup/route.ts
+++ b/app/api/parents-signup/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { blockBotRequest } from "@/lib/botid";
+import { isValidEmail } from "@/lib/email";
 
 export const dynamic = "force-dynamic";
 
@@ -9,9 +10,6 @@ const TABLE_NAME = "signup";
 function apiKey() {
   return process.env.PARENTS_AIRTABLE_KEY;
 }
-
-const isValidEmail = (v: unknown): v is string =>
-  typeof v === "string" && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v.trim());
 
 function clientIp(req: NextRequest) {
   const forwardedFor = req.headers.get("x-forwarded-for");

--- a/app/parents/page.tsx
+++ b/app/parents/page.tsx
@@ -1,0 +1,291 @@
+import type { Metadata } from "next";
+import Image from "next/image";
+import { Navbar } from "../../components/Navbar";
+import { Footer } from "../../components/Footer";
+import { YouTubeEmbed } from "../../components/YouTubeEmbed";
+import { buildPageMetadata } from "@/lib/seo";
+import { DonorsSection } from "../../components/landing/donors";
+import { ParentsEmailSignup } from "../../components/parents-email-signup";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "For Parents — Hack Club",
+  description:
+    "Hack Club is a welcoming, supportive space where teens can explore technology, make friends, and build things they're proud of — all with independence and agency.",
+  canonical: "/parents",
+});
+
+
+const F = "var(--font-phantom)";
+
+export default function ParentsPage() {
+  return (
+    <>
+      <Navbar />
+      <main id="main" tabIndex={-1}>
+        {/* Hero */}
+        <section
+          style={{
+            background: "var(--background)",
+            textAlign: "center",
+            paddingTop: 130,
+            paddingBottom: 60,
+            paddingLeft: "clamp(24px, 6vw, 80px)",
+            paddingRight: "clamp(24px, 6vw, 80px)",
+          }}
+        >
+          <h1
+            style={{
+              fontFamily: "var(--font-zarathustra)",
+              fontSize: "clamp(44px, 7.5vw, 84px)",
+              fontWeight: 300,
+              color: "var(--foreground)",
+              margin: "0 0 20px",
+              lineHeight: 1.1,
+            }}
+          >
+            For Parents
+          </h1>
+          <p
+            style={{
+              fontFamily: F,
+              fontSize: "clamp(14px, 2vw, 17px)",
+              color: "var(--muted)",
+              maxWidth: 560,
+              margin: "0 auto 32px",
+              lineHeight: 1.5,
+            }}
+          >
+            Hack Club is a safe, supportive space where teens 13 - 18 year olds can explore technology, make friends,
+            and build things they&apos;re proud of &mdash; all with independence and agency.
+          </p>
+
+          <ParentsEmailSignup />
+
+          <p
+            style={{
+              fontFamily: F,
+              fontSize: "clamp(15px, 2vw, 20px)",
+              fontWeight: 700,
+              color: "var(--foreground)",
+              margin: 0,
+            }}
+          >
+            Get monthly updates on coding opportunities, events, and new editions of the Hacker
+            Generation
+          </p>
+        </section>
+
+        {/* Hacker Generation Banner */}
+        <section
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            paddingBottom: 64,
+            paddingLeft: "clamp(24px, 6vw, 80px)",
+            paddingRight: "clamp(24px, 6vw, 80px)",
+            background: "var(--background)",
+          }}
+        >
+          <style>{`
+            .hacker-gen-card {
+              position: relative;
+              width: min(900px, 100%);
+              height: clamp(200px, 32vw, 320px);
+              border-radius: 16px;
+              overflow: hidden;
+              cursor: pointer;
+              transition: transform 300ms cubic-bezier(0.23, 1, 0.32, 1), box-shadow 300ms ease;
+            }
+            .hacker-gen-card:hover {
+              transform: scale(1.015);
+              box-shadow: 0 16px 48px rgba(0,0,0,0.3);
+            }
+            .hacker-gen-card:hover .hacker-gen-vignette {
+              opacity: 0.5;
+            }
+            .hacker-gen-vignette {
+              transition: opacity 300ms ease;
+            }
+            .hacker-gen-overlay-flat {
+              background: rgba(255,255,255,0.45);
+            }
+            .hacker-gen-overlay-grad {
+              background: linear-gradient(to bottom, rgba(255,255,255,0.85) 0%, rgba(255,255,255,0.6) 40%, rgba(255,255,255,0.2) 100%);
+            }
+            html.dark .hacker-gen-overlay-flat {
+              background: rgba(0,0,0,0.45);
+            }
+            html.dark .hacker-gen-overlay-grad {
+              background: linear-gradient(to bottom, rgba(0,0,0,0.80) 0%, rgba(0,0,0,0.5) 40%, rgba(0,0,0,0.15) 100%);
+            }
+          `}</style>
+          <a
+            href="https://christinaasquith.substack.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hacker-gen-card"
+            style={{ display: "block", textDecoration: "none" }}
+          >
+            <Image
+              src="https://cdn.hackclub.com/019e6ae0-7bb2-7290-9114-83e25b7bdc28/image.png"
+              alt="Hack Club members at a hackathon"
+              fill
+              style={{ objectFit: "cover", objectPosition: "center 30%" }}
+            />
+            {/* Overlay for readability — dark-mode aware via CSS classes */}
+            <div className="hacker-gen-vignette hacker-gen-overlay-flat" style={{ position: "absolute", inset: 0 }} />
+            <div className="hacker-gen-vignette hacker-gen-overlay-grad" style={{ position: "absolute", inset: 0 }} />
+            <div
+              style={{
+                position: "absolute",
+                inset: 0,
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "flex-start",
+                padding: "clamp(20px, 3.5vw, 36px) 32px 24px",
+                textAlign: "center",
+              }}
+            >
+              <h2
+                style={{
+                  fontFamily: "var(--font-zarathustra)",
+                  fontSize: "clamp(28px, 5vw, 52px)",
+                  fontWeight: 400,
+                  color: "#ec3750",
+                  margin: "0 0 10px",
+                  lineHeight: 1.1,
+                }}
+              >
+                The Hacker Generation
+              </h2>
+              <p
+                style={{
+                  fontFamily: "var(--font-zarathustra)",
+                  fontSize: "clamp(14px, 2vw, 20px)",
+                  fontWeight: 400,
+                  color: "#ec3750",
+                  margin: 0,
+                  opacity: 0.85,
+                }}
+              >
+                by Christina Asquith, co-founder of Hack Club
+              </p>
+            </div>
+          </a>
+        </section>
+
+        {/* Hack Club is: */}
+        <section
+          style={{
+            background: "#ec3750",
+            paddingTop: 64,
+            paddingBottom: 64,
+            paddingLeft: "clamp(32px, 10vw, 160px)",
+            paddingRight: "clamp(32px, 10vw, 160px)",
+          }}
+        >
+          <h2
+            style={{
+              fontFamily: F,
+              fontSize: "clamp(36px, 6vw, 64px)",
+              fontWeight: 700,
+              color: "#ffffff",
+              margin: "0 0 28px",
+              lineHeight: 1.1,
+            }}
+          >
+            Hack Club is:
+          </h2>
+          <ul
+            style={{
+              listStyle: "disc",
+              paddingLeft: 28,
+              margin: 0,
+              display: "flex",
+              flexDirection: "column",
+              gap: 16,
+            }}
+          >
+            <li
+              style={{ fontFamily: F, fontSize: "clamp(20px, 2.8vw, 28px)", color: "#ffffff", lineHeight: 1.45 }}
+            >
+              a nonprofit and the <strong>world&apos;s largest community</strong> of teenagers who
+              like to <strong>code</strong> and <strong>build awesome stuff.</strong>
+            </li>
+            <li
+              style={{ fontFamily: F, fontSize: "clamp(20px, 2.8vw, 28px)", color: "#ffffff", lineHeight: 1.45 }}
+            >
+              an <strong>online community</strong> that supports numerous{" "}
+              <strong>in-person events</strong> throughout the year.
+            </li>
+            <li
+              style={{ fontFamily: F, fontSize: "clamp(20px, 2.8vw, 28px)", color: "#ffffff", lineHeight: 1.45 }}
+            >
+              supported by Github, AMD, NASA and more
+            </li>
+            <li
+              style={{ fontFamily: F, fontSize: "clamp(20px, 2.8vw, 28px)", color: "#ffffff", lineHeight: 1.45 }}
+            >
+              always free for teens - no matter what.
+            </li>
+          </ul>
+        </section>
+
+        <DonorsSection minimal />
+
+        {/* Video */}
+        <section
+          style={{
+            background: "var(--background)",
+            paddingTop: 0,
+            paddingBottom: 80,
+            paddingLeft: "clamp(24px, 8vw, 120px)",
+            paddingRight: "clamp(24px, 8vw, 120px)",
+          }}
+        >
+          <div
+            style={{
+              maxWidth: 960,
+              margin: "0 auto",
+              display: "flex",
+              alignItems: "center",
+              gap: "clamp(32px, 5vw, 72px)",
+              flexWrap: "wrap",
+            }}
+          >
+            <p
+              style={{
+                flex: "1 1 200px",
+                fontFamily: "var(--font-zarathustra)",
+                fontSize: "clamp(20px, 2.4vw, 30px)",
+                color: "var(--foreground)",
+                margin: 0,
+                lineHeight: 1.3,
+                fontWeight: 400,
+              }}
+            >
+              See what teens experience at Hack Club Hackathons — from our Undercity Hackathon at GitHub HQ
+            </p>
+            <div
+              style={{
+                flex: "2 1 360px",
+                maxWidth: 580,
+                aspectRatio: "16 / 9",
+                borderRadius: 16,
+                overflow: "hidden",
+                boxShadow: "0 8px 32px rgba(0,0,0,0.12)",
+              }}
+            >
+              <YouTubeEmbed
+                id="kaEFv7e49mo"
+                title="We Hosted the Largest Hardware Hackathon — Hack Club Undercity at GitHub HQ"
+              />
+            </div>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/app/parents/page.tsx
+++ b/app/parents/page.tsx
@@ -14,7 +14,6 @@ export const metadata: Metadata = buildPageMetadata({
   canonical: "/parents",
 });
 
-
 const F = "var(--font-phantom)";
 
 export default function ParentsPage() {
@@ -55,8 +54,9 @@ export default function ParentsPage() {
               lineHeight: 1.5,
             }}
           >
-            Hack Club is a safe, supportive space where teens 13 - 18 year olds can explore technology, make friends,
-            and build things they&apos;re proud of &mdash; all with independence and agency.
+            Hack Club is a safe, supportive space where teens 13 - 18 year olds can explore
+            technology, make friends, and build things they&apos;re proud of &mdash; all with
+            independence and agency.
           </p>
 
           <ParentsEmailSignup />
@@ -133,8 +133,14 @@ export default function ParentsPage() {
               style={{ objectFit: "cover", objectPosition: "center 30%" }}
             />
             {/* Overlay for readability — dark-mode aware via CSS classes */}
-            <div className="hacker-gen-vignette hacker-gen-overlay-flat" style={{ position: "absolute", inset: 0 }} />
-            <div className="hacker-gen-vignette hacker-gen-overlay-grad" style={{ position: "absolute", inset: 0 }} />
+            <div
+              className="hacker-gen-vignette hacker-gen-overlay-flat"
+              style={{ position: "absolute", inset: 0 }}
+            />
+            <div
+              className="hacker-gen-vignette hacker-gen-overlay-grad"
+              style={{ position: "absolute", inset: 0 }}
+            />
             <div
               style={{
                 position: "absolute",
@@ -208,24 +214,44 @@ export default function ParentsPage() {
             }}
           >
             <li
-              style={{ fontFamily: F, fontSize: "clamp(20px, 2.8vw, 28px)", color: "#ffffff", lineHeight: 1.45 }}
+              style={{
+                fontFamily: F,
+                fontSize: "clamp(20px, 2.8vw, 28px)",
+                color: "#ffffff",
+                lineHeight: 1.45,
+              }}
             >
               a nonprofit and the <strong>world&apos;s largest community</strong> of teenagers who
               like to <strong>code</strong> and <strong>build awesome stuff.</strong>
             </li>
             <li
-              style={{ fontFamily: F, fontSize: "clamp(20px, 2.8vw, 28px)", color: "#ffffff", lineHeight: 1.45 }}
+              style={{
+                fontFamily: F,
+                fontSize: "clamp(20px, 2.8vw, 28px)",
+                color: "#ffffff",
+                lineHeight: 1.45,
+              }}
             >
               an <strong>online community</strong> that supports numerous{" "}
               <strong>in-person events</strong> throughout the year.
             </li>
             <li
-              style={{ fontFamily: F, fontSize: "clamp(20px, 2.8vw, 28px)", color: "#ffffff", lineHeight: 1.45 }}
+              style={{
+                fontFamily: F,
+                fontSize: "clamp(20px, 2.8vw, 28px)",
+                color: "#ffffff",
+                lineHeight: 1.45,
+              }}
             >
               supported by Github, AMD, NASA and more
             </li>
             <li
-              style={{ fontFamily: F, fontSize: "clamp(20px, 2.8vw, 28px)", color: "#ffffff", lineHeight: 1.45 }}
+              style={{
+                fontFamily: F,
+                fontSize: "clamp(20px, 2.8vw, 28px)",
+                color: "#ffffff",
+                lineHeight: 1.45,
+              }}
             >
               always free for teens - no matter what.
             </li>
@@ -265,7 +291,8 @@ export default function ParentsPage() {
                 fontWeight: 400,
               }}
             >
-              See what teens experience at Hack Club Hackathons — from our Undercity Hackathon at GitHub HQ
+              See what teens experience at Hack Club Hackathons — from our Undercity Hackathon at
+              GitHub HQ
             </p>
             <div
               style={{

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@types/prismjs": "^1.26.6",
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
+        "botid": "^1.5.11",
         "next": "16.2.10",
         "next-plausible": "^4.0.0",
         "prismjs": "^1.30.0",
@@ -255,6 +256,8 @@
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.42", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q=="],
+
+    "botid": ["botid@1.5.11", "", { "peerDependencies": { "next": "*", "react": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["next", "react"] }, "sha512-KOO1A3+/vFVJk5aFoG3sNwiogKFPVR+x4aw4gQ1b2e0XoE+i5xp48/EZn+WqR07jRHeDGwHWQUOtV5WVm7xiww=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001802", "", {}, "sha512-vmv8ub2xwTNmljSKf82mtCk5JH7hC+YgzLj3P5zotvA0tPQ9016tdNNOG8WRca1IxOnhSsivB+J0z5FeE5LOUw=="],
 

--- a/components/Icon.tsx
+++ b/components/Icon.tsx
@@ -13,7 +13,7 @@ export interface IconProps {
 export function Icon({ glyph, size = 40, style, className }: IconProps) {
   return (
     <HackclubIcon
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-anyfr
       glyph={glyph as any}
       size={size}
       style={style}

--- a/components/landing/donors.tsx
+++ b/components/landing/donors.tsx
@@ -57,61 +57,61 @@ export function DonorsSection({ minimal }: { minimal?: boolean } = {}) {
     >
       {!minimal && (
         <>
-      {/* Red gradient background — bottom portion only */}
-      <div
-        style={{
-          position: "absolute",
-          bottom: 0,
-          left: 0,
-          right: 0,
-          height: "30%",
-          background:
-            "linear-gradient(0deg, rgba(236,55,80,0.40) 0%, rgba(236,55,80,0.04) 75%, transparent 100%)",
-          pointerEvents: "none",
-          zIndex: 0,
-        }}
-      />
-      {/* Two-layer wave at gradient boundary — matches HeroSection WaveDivider style */}
-      <div
-        className="wave-container"
-        style={{
-          position: "absolute",
-          bottom: -2,
-          left: 0,
-          right: 0,
-          lineHeight: 0,
-          zIndex: 20,
-          pointerEvents: "none",
-        }}
-      >
-        {/* Thin stroke wave on top */}
-        <svg
-          viewBox="0 0 1920 22"
-          preserveAspectRatio="none"
-          style={{ width: "100%", height: 22, display: "block", marginBottom: -8 }}
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M0,18 C40,18 40,2 80,2 C120,2 120,18 160,18 C200,18 200,2 240,2 C280,2 280,18 320,18 C360,18 360,2 400,2 C440,2 440,18 480,18 C520,18 520,2 560,2 C600,2 600,18 640,18 C680,18 680,2 720,2 C760,2 760,18 800,18 C840,18 840,2 880,2 C920,2 920,18 960,18 C1000,18 1000,2 1040,2 C1080,2 1080,18 1120,18 C1160,18 1160,2 1200,2 C1240,2 1240,18 1280,18 C1320,18 1320,2 1360,2 C1400,2 1400,18 1440,18 C1480,18 1480,2 1520,2 C1560,2 1560,18 1600,18 C1640,18 1640,2 1680,2 C1720,2 1720,18 1760,18 C1800,18 1800,2 1840,2 C1880,2 1880,18 1920,18"
-            fill="none"
-            style={{ stroke: "var(--surface)" }}
-            strokeWidth="2.5"
-            vectorEffect="non-scaling-stroke"
+          {/* Red gradient background — bottom portion only */}
+          <div
+            style={{
+              position: "absolute",
+              bottom: 0,
+              left: 0,
+              right: 0,
+              height: "30%",
+              background:
+                "linear-gradient(0deg, rgba(236,55,80,0.40) 0%, rgba(236,55,80,0.04) 75%, transparent 100%)",
+              pointerEvents: "none",
+              zIndex: 0,
+            }}
           />
-        </svg>
-        {/* Main white fill wave */}
-        <svg
-          viewBox="0 0 1920 40"
-          preserveAspectRatio="none"
-          style={{ width: "100%", height: 40, display: "block" }}
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M0,40 L0,27 C40,27 40,8 80,8 C120,8 120,27 160,27 C200,27 200,8 240,8 C280,8 280,27 320,27 C360,27 360,8 400,8 C440,8 440,27 480,27 C520,27 520,8 560,8 C600,8 600,27 640,27 C680,27 680,8 720,8 C760,8 760,27 800,27 C840,27 840,8 880,8 C920,8 920,27 960,27 C1000,27 1000,8 1040,8 C1080,8 1080,27 1120,27 C1160,27 1160,8 1200,8 C1240,8 1240,27 1280,27 C1320,27 1320,8 1360,8 C1400,8 1400,27 1440,27 C1480,27 1480,8 1520,8 C1560,8 1560,27 1600,27 C1640,27 1640,8 1680,8 C1720,8 1720,27 1760,27 C1800,27 1800,8 1840,8 C1880,8 1880,27 1920,27 L1920,40 Z"
-            style={{ fill: "var(--surface)" }}
-          />
-        </svg>
-      </div>
+          {/* Two-layer wave at gradient boundary — matches HeroSection WaveDivider style */}
+          <div
+            className="wave-container"
+            style={{
+              position: "absolute",
+              bottom: -2,
+              left: 0,
+              right: 0,
+              lineHeight: 0,
+              zIndex: 20,
+              pointerEvents: "none",
+            }}
+          >
+            {/* Thin stroke wave on top */}
+            <svg
+              viewBox="0 0 1920 22"
+              preserveAspectRatio="none"
+              style={{ width: "100%", height: 22, display: "block", marginBottom: -8 }}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M0,18 C40,18 40,2 80,2 C120,2 120,18 160,18 C200,18 200,2 240,2 C280,2 280,18 320,18 C360,18 360,2 400,2 C440,2 440,18 480,18 C520,18 520,2 560,2 C600,2 600,18 640,18 C680,18 680,2 720,2 C760,2 760,18 800,18 C840,18 840,2 880,2 C920,2 920,18 960,18 C1000,18 1000,2 1040,2 C1080,2 1080,18 1120,18 C1160,18 1160,2 1200,2 C1240,2 1240,18 1280,18 C1320,18 1320,2 1360,2 C1400,2 1400,18 1440,18 C1480,18 1480,2 1520,2 C1560,2 1560,18 1600,18 C1640,18 1640,2 1680,2 C1720,2 1720,18 1760,18 C1800,18 1800,2 1840,2 C1880,2 1880,18 1920,18"
+                fill="none"
+                style={{ stroke: "var(--surface)" }}
+                strokeWidth="2.5"
+                vectorEffect="non-scaling-stroke"
+              />
+            </svg>
+            {/* Main white fill wave */}
+            <svg
+              viewBox="0 0 1920 40"
+              preserveAspectRatio="none"
+              style={{ width: "100%", height: 40, display: "block" }}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M0,40 L0,27 C40,27 40,8 80,8 C120,8 120,27 160,27 C200,27 200,8 240,8 C280,8 280,27 320,27 C360,27 360,8 400,8 C440,8 440,27 480,27 C520,27 520,8 560,8 C600,8 600,27 640,27 C680,27 680,8 720,8 C760,8 760,27 800,27 C840,27 840,8 880,8 C920,8 920,27 960,27 C1000,27 1000,8 1040,8 C1080,8 1080,27 1120,27 C1160,27 1160,8 1200,8 C1240,8 1240,27 1280,27 C1320,27 1320,8 1360,8 C1400,8 1400,27 1440,27 C1480,27 1480,8 1520,8 C1560,8 1560,27 1600,27 C1640,27 1640,8 1680,8 C1720,8 1720,27 1760,27 C1800,27 1800,8 1840,8 C1880,8 1880,27 1920,27 L1920,40 Z"
+                style={{ fill: "var(--surface)" }}
+              />
+            </svg>
+          </div>
         </>
       )}
       {/* Headline */}

--- a/components/landing/donors.tsx
+++ b/components/landing/donors.tsx
@@ -41,7 +41,7 @@ const donorNames = [
   "Tom Preston-Werner (Co-founder of GitHub)",
 ];
 
-export function DonorsSection() {
+export function DonorsSection({ minimal }: { minimal?: boolean } = {}) {
   return (
     <section
       className="section-padded"
@@ -49,12 +49,14 @@ export function DonorsSection() {
         position: "relative",
         background: "var(--background)",
         paddingTop: 80,
-        paddingBottom: 160,
+        paddingBottom: minimal ? 40 : 160,
         paddingLeft: "clamp(24px, 14.29%, 220px)",
         paddingRight: "clamp(24px, 14.29%, 220px)",
         textAlign: "center",
       }}
     >
+      {!minimal && (
+        <>
       {/* Red gradient background — bottom portion only */}
       <div
         style={{
@@ -110,6 +112,8 @@ export function DonorsSection() {
           />
         </svg>
       </div>
+        </>
+      )}
       {/* Headline */}
       <h2
         style={{
@@ -146,13 +150,14 @@ export function DonorsSection() {
         className="donor-logos-grid"
         style={{
           display: "flex",
-          flexWrap: "wrap",
+          flexWrap: minimal ? "nowrap" : "wrap",
           justifyContent: "center",
           alignItems: "center",
           gap: "clamp(24px, 3.5vw, 52px)",
-          maxWidth: 1080,
+          maxWidth: minimal ? "100%" : 1080,
           margin: "0 auto 24px",
           padding: "8px 0",
+          overflowX: minimal ? "auto" : undefined,
         }}
       >
         {donors.map((donor, i) => (

--- a/components/landing/email-signup.tsx
+++ b/components/landing/email-signup.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { isValidEmail } from "@/lib/email";
 import { sendToAuth } from "../../lib/send-auth";
 
 interface EmailSignupInputProps {
@@ -53,13 +54,8 @@ export function EmailSignupInput({ variant = "hero" }: EmailSignupInputProps) {
   const isVideo = variant === "video";
   const isReady = variant === "ready";
 
-  const isValid = (v: string) => {
-    const t = v.trim();
-    return t.length > 0 && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(t);
-  };
-
   const submit = () => {
-    if (!isValid(e)) {
+    if (!isValidEmail(e)) {
       setErr(true);
       return;
     }

--- a/components/parents-email-signup.tsx
+++ b/components/parents-email-signup.tsx
@@ -26,9 +26,9 @@ export function ParentsEmailSignup() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email: email.trim() }),
       });
-      if (res.status === 429) {
+      if (res.status === 403) {
         setStatus("error");
-        setErrorMsg("Too many attempts — try again later");
+        setErrorMsg("Unable to verify request — try again");
         return;
       }
       if (!res.ok) throw new Error();

--- a/components/parents-email-signup.tsx
+++ b/components/parents-email-signup.tsx
@@ -26,6 +26,11 @@ export function ParentsEmailSignup() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email: email.trim() }),
       });
+      if (res.status === 429) {
+        setStatus("error");
+        setErrorMsg("Too many attempts — try again later");
+        return;
+      }
       if (!res.ok) throw new Error();
       setStatus("success");
       setEmail("");

--- a/components/parents-email-signup.tsx
+++ b/components/parents-email-signup.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { isValidEmail } from "@/lib/email";
 
 const F = "var(--font-phantom)";
 
@@ -11,10 +12,8 @@ export function ParentsEmailSignup() {
   const [status, setStatus] = useState<Status>("idle");
   const [errorMsg, setErrorMsg] = useState("");
 
-  const isValid = (v: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v.trim());
-
   const submit = async () => {
-    if (!isValid(email)) {
+    if (!isValidEmail(email)) {
       setStatus("error");
       setErrorMsg("Enter a valid email address");
       return;

--- a/components/parents-email-signup.tsx
+++ b/components/parents-email-signup.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useState } from "react";
+
+const F = "var(--font-phantom)";
+
+type Status = "idle" | "loading" | "success" | "error";
+
+export function ParentsEmailSignup() {
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<Status>("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+
+  const isValid = (v: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v.trim());
+
+  const submit = async () => {
+    if (!isValid(email)) {
+      setStatus("error");
+      setErrorMsg("Enter a valid email address");
+      return;
+    }
+    setStatus("loading");
+    try {
+      const res = await fetch("/api/parents-signup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: email.trim() }),
+      });
+      if (!res.ok) throw new Error();
+      setStatus("success");
+      setEmail("");
+    } catch {
+      setStatus("error");
+      setErrorMsg("Something went wrong — try again");
+    }
+  };
+
+  const disabled = status === "loading" || status === "success";
+
+  return (
+    <>
+      <style>{`
+        #parents-email::placeholder { opacity: 0.5; }
+      `}</style>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          background: "var(--surface-hover)",
+          borderRadius: 9999,
+          width: "min(560px, calc(100vw - 48px))",
+          height: 52,
+          margin: "0 auto 20px",
+          boxShadow: status === "error" ? "0 0 0 2px var(--red)" : "none",
+          transition: "box-shadow 0.2s ease",
+        }}
+      >
+        <input
+          id="parents-email"
+          type="email"
+          placeholder="email"
+          value={email}
+          onChange={(e) => {
+            setEmail(e.target.value);
+            if (status === "error") setStatus("idle");
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") submit();
+          }}
+          disabled={disabled}
+          style={{
+            flex: 1,
+            minWidth: 0,
+            background: "transparent",
+            border: "none",
+            outline: "none",
+            paddingLeft: 24,
+            paddingRight: 8,
+            fontFamily: F,
+            fontSize: 16,
+            color: "var(--foreground)",
+          }}
+        />
+        <button
+          type="button"
+          onClick={submit}
+          disabled={disabled}
+          style={{
+            background: "var(--foreground)",
+            color: "var(--background)",
+            border: "none",
+            borderRadius: 9999,
+            height: 40,
+            paddingLeft: 20,
+            paddingRight: 20,
+            marginRight: 6,
+            fontFamily: F,
+            fontWeight: "normal",
+            fontSize: 16,
+            cursor: disabled ? "default" : "pointer",
+            flexShrink: 0,
+          }}
+        >
+          {status === "success" ? "Joined!" : status === "loading" ? "…" : "Sign up!"}
+        </button>
+      </div>
+      {status === "error" && (
+        <p
+          style={{
+            fontFamily: F,
+            fontSize: 14,
+            color: "var(--red)",
+            margin: "-8px auto 12px",
+            textAlign: "center",
+          }}
+        >
+          {errorMsg}
+        </p>
+      )}
+    </>
+  );
+}

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,0 +1,6 @@
+import { initBotId } from "botid/client/core";
+import { botIdProtectedRoutes } from "@/lib/botid-protected-routes";
+
+initBotId({
+  protect: botIdProtectedRoutes,
+});

--- a/lib/botid-protected-routes.ts
+++ b/lib/botid-protected-routes.ts
@@ -1,0 +1,15 @@
+export type BotIdProtectedRoute = {
+  path: string;
+  method: string;
+  advancedOptions?: {
+    checkLevel?: "basic" | "deepAnalysis";
+  };
+};
+
+export const botIdProtectedRoutes: BotIdProtectedRoute[] = [
+  {
+    path: "/api/parents-signup",
+    method: "POST",
+    advancedOptions: { checkLevel: "basic" },
+  },
+];

--- a/lib/botid.ts
+++ b/lib/botid.ts
@@ -1,0 +1,15 @@
+import { checkBotId } from "botid/server";
+import { NextResponse } from "next/server";
+import type { BotIdProtectedRoute } from "./botid-protected-routes";
+
+type BotIdCheckLevel = NonNullable<BotIdProtectedRoute["advancedOptions"]>["checkLevel"];
+
+export async function blockBotRequest(checkLevel: BotIdCheckLevel = "basic") {
+  const verification = await checkBotId({
+    advancedOptions: { checkLevel },
+  });
+
+  if (!verification.isBot) return null;
+
+  return NextResponse.json({ error: "Unable to verify request" }, { status: 403 });
+}

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,0 +1,25 @@
+function x(email: string): boolean {
+  const trimmed = email.trim();
+  if (trimmed.length === 0 || trimmed.length > 254) return false;
+
+  const at = trimmed.indexOf("@");
+  if (at < 1 || at !== trimmed.lastIndexOf("@")) return false;
+
+  const local = trimmed.slice(0, at);
+  const domain = trimmed.slice(at + 1);
+  if (local.length > 64 || domain.length === 0) return false;
+
+  const dot = domain.lastIndexOf(".");
+  if (dot < 1 || dot >= domain.length - 1) return false;
+
+  for (let i = 0; i < trimmed.length; i++) {
+    const code = trimmed.charCodeAt(i);
+    if (code <= 32 || code === 127) return false;
+  }
+
+  return true;
+}
+
+export function isValidEmail(value: unknown): value is string {
+  return typeof value === "string" && x(value);
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from "next";
 import { execSync } from "node:child_process";
+import { withBotId } from "botid/next/config";
 
 const getCommitSha = (): string => {
   const sha =
@@ -288,4 +289,4 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+export default withBotId(nextConfig);

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/prismjs": "^1.26.6",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
+    "botid": "^1.5.11",
     "next": "16.2.10",
     "next-plausible": "^4.0.0",
     "prismjs": "^1.30.0",


### PR DESCRIPTION
## Summary
- Adds a working email signup form to `/parents` (was previously a non-functional input)
- New `POST /api/parents-signup` route validates the email and writes a record (email + client IP when available) to the "signup" Airtable table

## Test plan
- [x] Type-checked with `tsc --noEmit`
- [x] Verified locally: valid email returns 200 and creates an Airtable record; invalid email returns 400 with no record created
- [x] Verified IP capture works when `x-forwarded-for` is present, degrades gracefully when absent (e.g. localhost)