### PR TITLE
Fix 404 page not rendering

### DIFF
--- a/app/[locale]/[...rest]/page.tsx
+++ b/app/[locale]/[...rest]/page.tsx
@@ -1,0 +1,5 @@
+import { notFound } from "next/navigation";
+
+export default function CatchAllPage() {
+  notFound();
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -37,7 +37,7 @@ const nextConfig: NextConfig = {
         }),
       ),
       {
-        source: "/fiscal-sponsorship/apply/",
+        source: "/fiscal-sponsorship/apply",
         destination: "https://hcb.hackclub.com/applications/new",
         permanent: false,
       },


### PR DESCRIPTION
The Vercel 404 page loads instead of Hack Club's page. This is due to the "Implement next-intl + add russian" (cba4191a) commit which moved pages and stuff.