### PR TITLE
fix: prevent homepage 500 when airtable fetch fails

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -33,12 +33,7 @@ export default async function Home({ params }: Props) {
   const { locale } = await params;
   setRequestLocale(locale);
 
-  let programs: ReturnType<typeof selectFeaturedPrograms> = [];
-  if (hasKey()) {
-    try {
-      programs = selectFeaturedPrograms(await fetchPrograms());
-    } catch {}
-  }
+  const programs = hasKey() ? selectFeaturedPrograms(await fetchPrograms()) : [];
 
   return (
     <>

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -33,7 +33,12 @@ export default async function Home({ params }: Props) {
   const { locale } = await params;
   setRequestLocale(locale);
 
-  const programs = hasKey() ? selectFeaturedPrograms(await fetchPrograms()) : [];
+  let programs: ReturnType<typeof selectFeaturedPrograms> = [];
+  if (hasKey()) {
+    try {
+      programs = selectFeaturedPrograms(await fetchPrograms());
+    } catch {}
+  }
 
   return (
     <>

--- a/lib/programs-data.ts
+++ b/lib/programs-data.ts
@@ -86,7 +86,12 @@ async function readPrograms({ fresh = false }: FetchProgramsOptions = {}): Promi
 }
 
 export async function fetchPrograms(): Promise<AirtableProgram[]> {
-  return readPrograms();
+  try {
+    return await readPrograms();
+  } catch (error) {
+    console.error("[programs] fetch failed", error);
+    return [];
+  }
 }
 
 export async function fetchProgramsFresh(): Promise<AirtableProgram[]> {


### PR DESCRIPTION
prevented a homepage 500 error when the airtable programs fetch fails by adding a try-catch. The "Imagine a world where you made this" section is now hidden instead of crashing the page