### PR TITLE
Change h1 text styling in clubs page

### DIFF
--- a/app/[locale]/clubs/page.tsx
+++ b/app/[locale]/clubs/page.tsx
@@ -153,6 +153,10 @@ export default async function ClubPage({ params }: Props) {
             paddingRight: "clamp(16px, 6vw, 80px)",
             background:
               "radial-gradient(1200px 500px at 50% -15%, rgba(236,55,80,0.45), rgba(236,55,80,0) 70%), linear-gradient(160deg, rgba(19,19,27,0.92) 0%, rgba(13,17,23,0.95) 100%), url('https://cdn.hackclub.com/019db857-6649-7f66-9184-21b9f538728a/joiningCard2Bg.webp') center/cover",
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            alignItems: "center",
           }}
         >
           <div

--- a/app/[locale]/clubs/page.tsx
+++ b/app/[locale]/clubs/page.tsx
@@ -178,17 +178,27 @@ export default async function ClubPage({ params }: Props) {
             <h1
               style={{
                 margin: "0 auto 18px",
-                maxWidth: 980,
+                maxWidth: 1500,
                 fontFamily: "var(--font-zarathustra)",
                 fontWeight: 400,
                 fontSize: "clamp(52px, 8.3vw, 114px)",
-                lineHeight: 0.93,
+                lineHeight: 1,
                 color: "var(--paper)",
               }}
             >
               {t("heroTitle1")}
               <br />
-              {t("heroTitle2")}
+              <div
+                style={{
+                  background:
+                    "linear-gradient(90deg, #ec3750 0%, #ff8c37 100%)",
+                  WebkitBackgroundClip: "text",
+                  WebkitTextFillColor: "transparent",
+                  backgroundClip: "text",
+                }}
+              >
+                {t("heroTitle2")}
+              </div>
             </h1>
             <p
               style={{
@@ -245,7 +255,8 @@ export default async function ClubPage({ params }: Props) {
                   display: "inline-flex",
                   alignItems: "center",
                   justifyContent: "center",
-                  background: "linear-gradient(135deg, #338eda 0%, #33d6a6 100%)",
+                  background:
+                    "linear-gradient(135deg, #338eda 0%, #33d6a6 100%)",
                   color: "var(--paper)",
                   borderRadius: 999,
                   height: 56,
@@ -570,7 +581,9 @@ export default async function ClubPage({ params }: Props) {
             padding: "clamp(64px, 8.5vw, 106px) clamp(16px, 6vw, 80px)",
           }}
         >
-          <div style={{ maxWidth: 1120, margin: "0 auto", textAlign: "center" }}>
+          <div
+            style={{ maxWidth: 1120, margin: "0 auto", textAlign: "center" }}
+          >
             <h2
               style={{
                 margin: "0 0 14px",

--- a/app/[locale]/clubs/page.tsx
+++ b/app/[locale]/clubs/page.tsx
@@ -194,8 +194,7 @@ export default async function ClubPage({ params }: Props) {
               <br />
               <div
                 style={{
-                  background:
-                    "linear-gradient(90deg, #ec3750 0%, #ff8c37 100%)",
+                  background: "linear-gradient(90deg, #ec3750 0%, #ff8c37 100%)",
                   WebkitBackgroundClip: "text",
                   WebkitTextFillColor: "transparent",
                   backgroundClip: "text",
@@ -259,8 +258,7 @@ export default async function ClubPage({ params }: Props) {
                   display: "inline-flex",
                   alignItems: "center",
                   justifyContent: "center",
-                  background:
-                    "linear-gradient(135deg, #338eda 0%, #33d6a6 100%)",
+                  background: "linear-gradient(135deg, #338eda 0%, #33d6a6 100%)",
                   color: "var(--paper)",
                   borderRadius: 999,
                   height: 56,
@@ -585,9 +583,7 @@ export default async function ClubPage({ params }: Props) {
             padding: "clamp(64px, 8.5vw, 106px) clamp(16px, 6vw, 80px)",
           }}
         >
-          <div
-            style={{ maxWidth: 1120, margin: "0 auto", textAlign: "center" }}
-          >
+          <div style={{ maxWidth: 1120, margin: "0 auto", textAlign: "center" }}>
             <h2
               style={{
                 margin: "0 0 14px",


### PR DESCRIPTION
adds +500 aura
- width increased to prevent "Hack Club" from wrapping on most screens making the h1 3 lines instead of 4 because of the final word
- line height increased a bit so text doesn't collide
- added gradient to "Make it a hack club" for extra aura points
- centered with flex so it doesn't look weird/off-center on mobile/tablet screens

## PC
| After | Before |
|--------|--------|
| <img width="1916" height="959" alt="image" src="https://github.com/user-attachments/assets/f827ea2c-ed95-40ca-ba7f-0c9a78228f59" /> | <img width="1920" height="956" alt="image" src="https://github.com/user-attachments/assets/68100e52-44fe-4fd1-b5f4-88d3b8179e41" /> | 

## iPad Pro

| After | Before |
|--------|--------|
| <img width="697" height="795" alt="image" src="https://github.com/user-attachments/assets/6ae77dba-d2ee-4fa2-a925-324a8f540c66" />| <img width="671" height="765" alt="image" src="https://github.com/user-attachments/assets/284ea057-d396-4316-815e-b6166f55a51d" /> | 



