### PR TITLE
Change Hackclubber to Hack Clubber to follow the Hack Club branding

### DIFF
--- a/public/acknowledged.json
+++ b/public/acknowledged.json
@@ -411,7 +411,7 @@
     "department": "HQ",
     "role": "Engineering",
     "acknowledged": true,
-    "bio": "Kate is a Hackclubber from Manassas Virginia who loves cookies and the color yellow. Currently studying Engineering at George Mason University and Osbourn Park High School, she works mainly with logistics and running the YSWS program BakeBuild. In addition she also helps to run and win hackathons in Northern Virginia with events such as Counterspell, Scrapyard, and [REHACTED].",
+    "bio": "Kate is a Hack Clubber from Manassas Virginia who loves cookies and the color yellow. Currently studying Engineering at George Mason University and Osbourn Park High School, she works mainly with logistics and running the YSWS program BakeBuild. In addition she also helps to run and win hackathons in Northern Virginia with events such as Counterspell, Scrapyard, and [REHACTED].",
     "slackId": "U07PXU0657B",
     "email": "katec",
     "website": "",


### PR DESCRIPTION
https://hackclub.enterprise.slack.com/archives/C07MUPSKYUS/p1759977663690819
[This fix was made with the use of automated tools]